### PR TITLE
hotfix npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,15 +21,6 @@ jobs:
     - name: "tests"
       run: npm run test
 
-    - name: Publish to NPM
-      if: github.event_name == 'push' && (contains(github.ref, 'tags') || github.ref == 'refs/heads/master')
-      run: |
-        npm config set //registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN
-        npm publish
-      env:
-        NPM_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      continue-on-error: true
-
     - name: Publish CML docker image
       # only publish if push to master (dvcorg/cml:latest) 
       # or create a tag in the repo (dvcorg/cml:tag)
@@ -92,3 +83,10 @@ jobs:
         cache: true
         tag_names: true
 
+    - name: Publish to NPM
+      if: github.event_name == 'push' && (contains(github.ref, 'tags') || github.ref == 'refs/heads/master')
+      run: |
+        npm config set //registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN
+        npm publish
+      env:
+        NPM_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cml",
+  "name": "@dvcorg/cml",
   "version": "0.1.0",
   "author": {
     "name": "DVC",


### PR DESCRIPTION
Despite that npm check version was intensively tested [here](https://github.com/DavidGOrtega/npmtest) , I see that it does not work properly. Sometimes it fails.

This PR:
 - Removes npm version check
 - add scope to package
 - do npm publish the very last so we. wont have errors if the package uploaded successfully and failed then in publishing to docker. 