### PR TITLE
doc: Fix REPO_TOKEN in aws example

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: cml_run
         env:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          repo_token: ${{ secrets.REPO_TOKEN }}
         run: |
           pip install -r requirements.txt
           python train.py


### PR DESCRIPTION
I believe that `GITHUB_TOKEN` cannot be used as `repo_token` in this example. (I know it is acceptable in some cases.)

With `GITHUB_TOKEN`, the EC2 runner seemed to fail in connection with GitHub Actions. Replacing `GITHUB_TOKEN` with `REPO_TOKEN` solved the issue.