### PR TITLE
Support setup-python@v2 action

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -90,6 +90,7 @@ RUN apt update && \
 # OUR DOCKER_MACHINE FORK SUPPORTS GPU ACCELARATOR
 ENV RUNNER_PATH=/home/runner
 ENV RUNNER_ALLOW_RUNASROOT=1
+ENV AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache/
 
 RUN curl -fsSL https://get.docker.com -o get-docker.sh && sh get-docker.sh && \
     curl -L "https://github.com/docker/compose/releases/download/1.24.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \


### PR DESCRIPTION
This PR sets the `AGENT_TOOLSDIRECTORY` environment variable, which is required for the setup-python (v2 only) action to work correctly.

This should close #81.