### PR TITLE
Python setup action volume in workflow not needed

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -91,7 +91,7 @@ RUN apt update && \
 ENV RUNNER_PATH=/home/runner
 ENV RUNNER_ALLOW_RUNASROOT=1
 
-# FIXES Python Action
+# FIXES Python setup Action
 RUN mkdir /__t
 RUN ln -s /__t /opt/hostedtoolcache
 ENV AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -90,7 +90,11 @@ RUN apt update && \
 # OUR DOCKER_MACHINE FORK SUPPORTS GPU ACCELARATOR
 ENV RUNNER_PATH=/home/runner
 ENV RUNNER_ALLOW_RUNASROOT=1
-ENV AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache/
+
+# FIXES Python Action
+RUN mkdir /__t
+RUN ln -s /__t /opt/hostedtoolcache
+ENV AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache
 
 RUN curl -fsSL https://get.docker.com -o get-docker.sh && sh get-docker.sh && \
     curl -L "https://github.com/docker/compose/releases/download/1.24.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \


### PR DESCRIPTION
Thanks to @jbencook we were able to put back [Python setup](https://github.com/actions/setup-python) in shape.
However the volume had to be specified in the workflow #81 

This PR eliminates the need of having to setup the volume in the workflow ending with a simpler yaml:


```yaml
run:
    runs-on: [ubuntu-latest]
    container:
      image: docker://dvcorg/cml-dev:pyv10

    steps:
      - uses: actions/checkout@v2
      
      - name: Set up Python
        uses: actions/setup-python@v2
        with:
          python-version: '3.x'
          
      - name: Display Python version
        run: python -c "import sys; print(sys.version)"
``` 

Works for GH runners and self-hosted runners.