### PR TITLE
use GITHUB_ACTIONS to check if running inside a Github Action

### DIFF
--- a/bin/cml-publish.js
+++ b/bin/cml-publish.js
@@ -6,35 +6,33 @@ console.log = console.error;
 const fs = require('fs').promises;
 const pipe_args = require('../src/pipe-args');
 const yargs = require('yargs');
-const {publish_file} = require('../src/report');
+const { publish_file } = require('../src/report');
 
-const {handle_error} = process.env.GITHUB_ACTIONS ? require('../src/github')
-                                                  : require('../src/gitlab');
+const { handle_error } = process.env.GITHUB_ACTIONS
+  ? require('../src/github')
+  : require('../src/gitlab');
 
-const run = async opts => {
-  const {file, md, title} = opts;
+const run = async (opts) => {
+  const { file, md, title } = opts;
   const path = opts._[0];
 
   let buffer;
-  if (data)
-    buffer = Buffer.from(data, 'binary');
+  if (data) buffer = Buffer.from(data, 'binary');
 
-  const output = await publish_file({path, buffer, md, title});
-  if (!file)
-    print(output);
-  else
-    await fs.writeFile(file, output);
+  const output = await publish_file({ path, buffer, md, title });
+  if (!file) print(output);
+  else await fs.writeFile(file, output);
 };
 
 pipe_args.load('binary');
 const data = pipe_args.piped_arg();
-const argv = yargs.usage(`Usage: $0 <path> --file <string>`)
-                 .boolean('md')
-                 .default('title')
-                 .alias('t', 'title')
-                 .default('file')
-                 .alias('f', 'file')
-                 .help('h')
-                 .demand(data ? 0 : 1)
-                 .argv;
-run({...argv, data}).catch(e => handle_error(e));
+const argv = yargs
+  .usage(`Usage: $0 <path> --file <string>`)
+  .boolean('md')
+  .default('title')
+  .alias('t', 'title')
+  .default('file')
+  .alias('f', 'file')
+  .help('h')
+  .demand(data ? 0 : 1).argv;
+run({ ...argv, data }).catch((e) => handle_error(e));

--- a/bin/cml-publish.js
+++ b/bin/cml-publish.js
@@ -12,7 +12,7 @@ const { handle_error } = process.env.GITHUB_ACTIONS
   ? require('../src/github')
   : require('../src/gitlab');
 
-const run = async (opts) => {
+const run = async opts => {
   const { file, md, title } = opts;
   const path = opts._[0];
 
@@ -35,4 +35,4 @@ const argv = yargs
   .alias('f', 'file')
   .help('h')
   .demand(data ? 0 : 1).argv;
-run({ ...argv, data }).catch((e) => handle_error(e));
+run({ ...argv, data }).catch(e => handle_error(e));

--- a/bin/cml-publish.js
+++ b/bin/cml-publish.js
@@ -6,33 +6,35 @@ console.log = console.error;
 const fs = require('fs').promises;
 const pipe_args = require('../src/pipe-args');
 const yargs = require('yargs');
-const { publish_file } = require('../src/report');
+const {publish_file} = require('../src/report');
 
-const { handle_error } = process.env.GITHUB_ACTIONS
-  ? require('../src/github')
-  : require('../src/gitlab');
+const {handle_error} = process.env.GITHUB_ACTIONS ? require('../src/github')
+                                                  : require('../src/gitlab');
 
 const run = async opts => {
-  const { file, md, title } = opts;
+  const {file, md, title} = opts;
   const path = opts._[0];
 
   let buffer;
-  if (data) buffer = Buffer.from(data, 'binary');
+  if (data)
+    buffer = Buffer.from(data, 'binary');
 
-  const output = await publish_file({ path, buffer, md, title });
-  if (!file) print(output);
-  else await fs.writeFile(file, output);
+  const output = await publish_file({path, buffer, md, title});
+  if (!file)
+    print(output);
+  else
+    await fs.writeFile(file, output);
 };
 
 pipe_args.load('binary');
 const data = pipe_args.piped_arg();
-const argv = yargs
-  .usage(`Usage: $0 <path> --file <string>`)
-  .boolean('md')
-  .default('title')
-  .alias('t', 'title')
-  .default('file')
-  .alias('f', 'file')
-  .help('h')
-  .demand(data ? 0 : 1).argv;
-run({ ...argv, data }).catch(e => handle_error(e));
+const argv = yargs.usage(`Usage: $0 <path> --file <string>`)
+                 .boolean('md')
+                 .default('title')
+                 .alias('t', 'title')
+                 .default('file')
+                 .alias('f', 'file')
+                 .help('h')
+                 .demand(data ? 0 : 1)
+                 .argv;
+run({...argv, data}).catch(e => handle_error(e));

--- a/bin/cml-publish.js
+++ b/bin/cml-publish.js
@@ -8,7 +8,7 @@ const pipe_args = require('../src/pipe-args');
 const yargs = require('yargs');
 const { publish_file } = require('../src/report');
 
-const { handle_error } = process.env.GITHUB_ACTION
+const { handle_error } = process.env.GITHUB_ACTIONS
   ? require('../src/github')
   : require('../src/gitlab');
 

--- a/bin/cml-send-comment.js
+++ b/bin/cml-send-comment.js
@@ -9,7 +9,7 @@ const { head_sha: HEAD_SHA, handle_error, comment } = process.env.GITHUB_ACTIONS
   ? require('../src/github')
   : require('../src/gitlab');
 
-const run = async (opts) => {
+const run = async opts => {
   const { 'head-sha': head_sha = HEAD_SHA } = opts;
   const path = opts._[0];
   const report = await fs.readFile(path, 'utf-8');
@@ -23,4 +23,4 @@ const argv = yargs
   .describe('head-sha', 'Commit sha')
   .help('h')
   .demand(1).argv;
-run(argv).catch((e) => handle_error(e));
+run(argv).catch(e => handle_error(e));

--- a/bin/cml-send-comment.js
+++ b/bin/cml-send-comment.js
@@ -5,22 +5,22 @@ console.log = console.error;
 const fs = require('fs').promises;
 const yargs = require('yargs');
 
-const {head_sha : HEAD_SHA, handle_error, comment} =
-    process.env.GITHUB_ACTIONS ? require('../src/github')
-                               : require('../src/gitlab');
+const { head_sha: HEAD_SHA, handle_error, comment } = process.env.GITHUB_ACTIONS
+  ? require('../src/github')
+  : require('../src/gitlab');
 
-const run = async opts => {
-  const {'head-sha' : head_sha = HEAD_SHA} = opts;
+const run = async (opts) => {
+  const { 'head-sha': head_sha = HEAD_SHA } = opts;
   const path = opts._[0];
   const report = await fs.readFile(path, 'utf-8');
 
-  await comment({head_sha, report});
+  await comment({ head_sha, report });
 };
 
-const argv = yargs.usage(`Usage: $0 <path> --head-sha <string>`)
-                 .default('head-sha')
-                 .describe('head-sha', 'Commit sha')
-                 .help('h')
-                 .demand(1)
-                 .argv;
-run(argv).catch(e => handle_error(e));
+const argv = yargs
+  .usage(`Usage: $0 <path> --head-sha <string>`)
+  .default('head-sha')
+  .describe('head-sha', 'Commit sha')
+  .help('h')
+  .demand(1).argv;
+run(argv).catch((e) => handle_error(e));

--- a/bin/cml-send-comment.js
+++ b/bin/cml-send-comment.js
@@ -5,7 +5,7 @@ console.log = console.error;
 const fs = require('fs').promises;
 const yargs = require('yargs');
 
-const { head_sha: HEAD_SHA, handle_error, comment } = process.env.GITHUB_ACTION
+const { head_sha: HEAD_SHA, handle_error, comment } = process.env.GITHUB_ACTIONS
   ? require('../src/github')
   : require('../src/gitlab');
 

--- a/bin/cml-send-comment.js
+++ b/bin/cml-send-comment.js
@@ -5,25 +5,22 @@ console.log = console.error;
 const fs = require('fs').promises;
 const yargs = require('yargs');
 
-const { head_sha: HEAD_SHA, handle_error, comment } = process.env.GITHUB_ACTIONS
-  ? require('../src/github')
-  : require('../src/gitlab');
+const {head_sha : HEAD_SHA, handle_error, comment} =
+    process.env.GITHUB_ACTIONS ? require('../src/github')
+                               : require('../src/gitlab');
 
 const run = async opts => {
-  const { 'head-sha': head_sha = HEAD_SHA } = opts;
+  const {'head-sha' : head_sha = HEAD_SHA} = opts;
   const path = opts._[0];
   const report = await fs.readFile(path, 'utf-8');
 
-  await comment({
-    head_sha,
-    report
-  });
+  await comment({head_sha, report});
 };
 
-const argv = yargs
-  .usage(`Usage: $0 <path> --head-sha <string>`)
-  .default('head-sha')
-  .describe('head-sha', 'Commit sha')
-  .help('h')
-  .demand(1).argv;
+const argv = yargs.usage(`Usage: $0 <path> --head-sha <string>`)
+                 .default('head-sha')
+                 .describe('head-sha', 'Commit sha')
+                 .help('h')
+                 .demand(1)
+                 .argv;
 run(argv).catch(e => handle_error(e));

--- a/bin/cml-send-comment.test.js
+++ b/bin/cml-send-comment.test.js
@@ -1,21 +1,24 @@
 jest.setTimeout(200000);
 
-const {exec} = require('../src/utils');
+const { exec } = require('../src/utils');
 const fs = require('fs').promises;
-const {publish_file} = require('../src/report');
+const { publish_file } = require('../src/report');
 
 describe('CML e2e', () => {
   test('cml-send-comment', async () => {
     const path = 'comment.md';
-    const img = await publish_file(
-        {path : 'assets/logo.png', md : true, title : 'logo'});
+    const img = await publish_file({
+      path: 'assets/logo.png',
+      md: true,
+      title: 'logo'
+    });
 
     const report = `## Test Comment Report \n ${img}`;
 
     await fs.writeFile(path, report);
 
     process.env.GITHUB_ACTIONS &&
-        (await exec(`node ./bin/cml-send-comment.js ${path}`));
+      (await exec(`node ./bin/cml-send-comment.js ${path}`));
 
     await fs.unlink(path);
   });

--- a/bin/cml-send-comment.test.js
+++ b/bin/cml-send-comment.test.js
@@ -1,24 +1,21 @@
 jest.setTimeout(200000);
 
-const { exec } = require('../src/utils');
+const {exec} = require('../src/utils');
 const fs = require('fs').promises;
-const { publish_file } = require('../src/report');
+const {publish_file} = require('../src/report');
 
 describe('CML e2e', () => {
   test('cml-send-comment', async () => {
     const path = 'comment.md';
-    const img = await publish_file({
-      path: 'assets/logo.png',
-      md: true,
-      title: 'logo'
-    });
+    const img = await publish_file(
+        {path : 'assets/logo.png', md : true, title : 'logo'});
 
     const report = `## Test Comment Report \n ${img}`;
 
     await fs.writeFile(path, report);
 
     process.env.GITHUB_ACTIONS &&
-      (await exec(`node ./bin/cml-send-comment.js ${path}`));
+        (await exec(`node ./bin/cml-send-comment.js ${path}`));
 
     await fs.unlink(path);
   });

--- a/bin/cml-send-comment.test.js
+++ b/bin/cml-send-comment.test.js
@@ -17,7 +17,7 @@ describe('CML e2e', () => {
 
     await fs.writeFile(path, report);
 
-    process.env.GITHUB_ACTION &&
+    process.env.GITHUB_ACTIONS &&
       (await exec(`node ./bin/cml-send-comment.js ${path}`));
 
     await fs.unlink(path);

--- a/bin/cml-send-github-check.js
+++ b/bin/cml-send-github-check.js
@@ -5,42 +5,29 @@ console.log = console.error;
 const fs = require('fs').promises;
 const yargs = require('yargs');
 
-const {
-  head_sha: HEAD_SHA,
-  handle_error,
-  create_check_report,
-  CHECK_TITLE
-} = process.env.GITHUB_ACTIONS
-  ? require('../src/github')
-  : require('../src/gitlab');
+const {head_sha : HEAD_SHA, handle_error, create_check_report, CHECK_TITLE} =
+    process.env.GITHUB_ACTIONS ? require('../src/github')
+                               : require('../src/gitlab');
 
 const run = async opts => {
-  const { 'head-sha': head_sha = HEAD_SHA, conclusion, title } = opts;
+  const {'head-sha' : head_sha = HEAD_SHA, conclusion, title} = opts;
   const path = opts._[0];
   const report = await fs.readFile(path, 'utf-8');
 
-  await create_check_report({
-    head_sha,
-    report,
-    conclusion,
-    title
-  });
+  await create_check_report({head_sha, report, conclusion, title});
 };
 
-const argv = yargs
-  .usage(`Usage: $0 <path> --head-sha <string>`)
-  .default('head-sha')
-  .default('conclusion', 'success')
-  .choices('conclusion', [
-    'success',
-    'failure',
-    'neutral',
-    'cancelled',
-    'skipped',
-    'timed_out'
-  ])
-  .default('title', CHECK_TITLE)
-  .describe('head-sha', 'Commit sha')
-  .help('h')
-  .demand(1).argv;
+const argv = yargs.usage(`Usage: $0 <path> --head-sha <string>`)
+                 .default('head-sha')
+                 .default('conclusion', 'success')
+                 .choices('conclusion',
+                          [
+                            'success', 'failure', 'neutral', 'cancelled',
+                            'skipped', 'timed_out'
+                          ])
+                 .default('title', CHECK_TITLE)
+                 .describe('head-sha', 'Commit sha')
+                 .help('h')
+                 .demand(1)
+                 .argv;
 run(argv).catch(e => handle_error(e));

--- a/bin/cml-send-github-check.js
+++ b/bin/cml-send-github-check.js
@@ -14,7 +14,7 @@ const {
   ? require('../src/github')
   : require('../src/gitlab');
 
-const run = async (opts) => {
+const run = async opts => {
   const { 'head-sha': head_sha = HEAD_SHA, conclusion, title } = opts;
   const path = opts._[0];
   const report = await fs.readFile(path, 'utf-8');
@@ -38,4 +38,4 @@ const argv = yargs
   .describe('head-sha', 'Commit sha')
   .help('h')
   .demand(1).argv;
-run(argv).catch((e) => handle_error(e));
+run(argv).catch(e => handle_error(e));

--- a/bin/cml-send-github-check.js
+++ b/bin/cml-send-github-check.js
@@ -5,29 +5,37 @@ console.log = console.error;
 const fs = require('fs').promises;
 const yargs = require('yargs');
 
-const {head_sha : HEAD_SHA, handle_error, create_check_report, CHECK_TITLE} =
-    process.env.GITHUB_ACTIONS ? require('../src/github')
-                               : require('../src/gitlab');
+const {
+  head_sha: HEAD_SHA,
+  handle_error,
+  create_check_report,
+  CHECK_TITLE
+} = process.env.GITHUB_ACTIONS
+  ? require('../src/github')
+  : require('../src/gitlab');
 
-const run = async opts => {
-  const {'head-sha' : head_sha = HEAD_SHA, conclusion, title} = opts;
+const run = async (opts) => {
+  const { 'head-sha': head_sha = HEAD_SHA, conclusion, title } = opts;
   const path = opts._[0];
   const report = await fs.readFile(path, 'utf-8');
 
-  await create_check_report({head_sha, report, conclusion, title});
+  await create_check_report({ head_sha, report, conclusion, title });
 };
 
-const argv = yargs.usage(`Usage: $0 <path> --head-sha <string>`)
-                 .default('head-sha')
-                 .default('conclusion', 'success')
-                 .choices('conclusion',
-                          [
-                            'success', 'failure', 'neutral', 'cancelled',
-                            'skipped', 'timed_out'
-                          ])
-                 .default('title', CHECK_TITLE)
-                 .describe('head-sha', 'Commit sha')
-                 .help('h')
-                 .demand(1)
-                 .argv;
-run(argv).catch(e => handle_error(e));
+const argv = yargs
+  .usage(`Usage: $0 <path> --head-sha <string>`)
+  .default('head-sha')
+  .default('conclusion', 'success')
+  .choices('conclusion', [
+    'success',
+    'failure',
+    'neutral',
+    'cancelled',
+    'skipped',
+    'timed_out'
+  ])
+  .default('title', CHECK_TITLE)
+  .describe('head-sha', 'Commit sha')
+  .help('h')
+  .demand(1).argv;
+run(argv).catch((e) => handle_error(e));

--- a/bin/cml-send-github-check.js
+++ b/bin/cml-send-github-check.js
@@ -10,7 +10,7 @@ const {
   handle_error,
   create_check_report,
   CHECK_TITLE
-} = process.env.GITHUB_ACTION
+} = process.env.GITHUB_ACTIONS
   ? require('../src/github')
   : require('../src/gitlab');
 

--- a/bin/cml-send-github-check.test.js
+++ b/bin/cml-send-github-check.test.js
@@ -1,37 +1,43 @@
 jest.setTimeout(200000);
 
-const {exec} = require('../src/utils');
+const { exec } = require('../src/utils');
 const fs = require('fs').promises;
-const {publish_file} = require('../src/report');
+const { publish_file } = require('../src/report');
 
 describe('CML e2e', () => {
   test('cml-send-github-check', async () => {
     const path = 'check.md';
-    const img = await publish_file(
-        {path : 'assets/logo.png', md : true, title : 'logo'});
-    const pdf = await publish_file(
-        {path : 'assets/logo.pdf', md : true, title : 'logo'});
+    const img = await publish_file({
+      path: 'assets/logo.png',
+      md: true,
+      title: 'logo'
+    });
+    const pdf = await publish_file({
+      path: 'assets/logo.pdf',
+      md: true,
+      title: 'logo'
+    });
     const report = `## Test Check Report \n ${img} \n ${pdf}`;
 
     await fs.writeFile(path, report);
     process.env.GITHUB_ACTIONS &&
-        (await exec(`node ./bin/cml-send-github-check.js ${path}`));
+      (await exec(`node ./bin/cml-send-github-check.js ${path}`));
     await fs.unlink(path);
   });
 
-  test('cml-send-github-check failure with tile "CML neutral test"',
-       async () => {
-         const path = 'check.md';
-         const report = `## Hi this check should be neutral`;
-         const title = 'CML neutral test';
-         const conclusion = 'neutral';
+  test('cml-send-github-check failure with tile "CML neutral test"', async () => {
+    const path = 'check.md';
+    const report = `## Hi this check should be neutral`;
+    const title = 'CML neutral test';
+    const conclusion = 'neutral';
 
-         await fs.writeFile(path, report);
-         process.env.GITHUB_ACTIONS &&
-             (await exec(`node ./bin/cml-send-github-check.js ${
-                 path} --title "${title}" --conclusion "${conclusion}"`));
-         await fs.unlink(path);
-       });
+    await fs.writeFile(path, report);
+    process.env.GITHUB_ACTIONS &&
+      (await exec(
+        `node ./bin/cml-send-github-check.js ${path} --title "${title}" --conclusion "${conclusion}"`
+      ));
+    await fs.unlink(path);
+  });
 
   test('cml-send-github-check -h', async () => {
     const output = await exec(`node ./bin/cml-send-github-check.js -h`);

--- a/bin/cml-send-github-check.test.js
+++ b/bin/cml-send-github-check.test.js
@@ -1,43 +1,37 @@
 jest.setTimeout(200000);
 
-const { exec } = require('../src/utils');
+const {exec} = require('../src/utils');
 const fs = require('fs').promises;
-const { publish_file } = require('../src/report');
+const {publish_file} = require('../src/report');
 
 describe('CML e2e', () => {
   test('cml-send-github-check', async () => {
     const path = 'check.md';
-    const img = await publish_file({
-      path: 'assets/logo.png',
-      md: true,
-      title: 'logo'
-    });
-    const pdf = await publish_file({
-      path: 'assets/logo.pdf',
-      md: true,
-      title: 'logo'
-    });
+    const img = await publish_file(
+        {path : 'assets/logo.png', md : true, title : 'logo'});
+    const pdf = await publish_file(
+        {path : 'assets/logo.pdf', md : true, title : 'logo'});
     const report = `## Test Check Report \n ${img} \n ${pdf}`;
 
     await fs.writeFile(path, report);
     process.env.GITHUB_ACTIONS &&
-      (await exec(`node ./bin/cml-send-github-check.js ${path}`));
+        (await exec(`node ./bin/cml-send-github-check.js ${path}`));
     await fs.unlink(path);
   });
 
-  test('cml-send-github-check failure with tile "CML neutral test"', async () => {
-    const path = 'check.md';
-    const report = `## Hi this check should be neutral`;
-    const title = 'CML neutral test';
-    const conclusion = 'neutral';
+  test('cml-send-github-check failure with tile "CML neutral test"',
+       async () => {
+         const path = 'check.md';
+         const report = `## Hi this check should be neutral`;
+         const title = 'CML neutral test';
+         const conclusion = 'neutral';
 
-    await fs.writeFile(path, report);
-    process.env.GITHUB_ACTIONS &&
-      (await exec(
-        `node ./bin/cml-send-github-check.js ${path} --title "${title}" --conclusion "${conclusion}"`
-      ));
-    await fs.unlink(path);
-  });
+         await fs.writeFile(path, report);
+         process.env.GITHUB_ACTIONS &&
+             (await exec(`node ./bin/cml-send-github-check.js ${
+                 path} --title "${title}" --conclusion "${conclusion}"`));
+         await fs.unlink(path);
+       });
 
   test('cml-send-github-check -h', async () => {
     const output = await exec(`node ./bin/cml-send-github-check.js -h`);

--- a/bin/cml-send-github-check.test.js
+++ b/bin/cml-send-github-check.test.js
@@ -20,7 +20,7 @@ describe('CML e2e', () => {
     const report = `## Test Check Report \n ${img} \n ${pdf}`;
 
     await fs.writeFile(path, report);
-    process.env.GITHUB_ACTION &&
+    process.env.GITHUB_ACTIONS &&
       (await exec(`node ./bin/cml-send-github-check.js ${path}`));
     await fs.unlink(path);
   });
@@ -32,7 +32,7 @@ describe('CML e2e', () => {
     const conclusion = 'neutral';
 
     await fs.writeFile(path, report);
-    process.env.GITHUB_ACTION &&
+    process.env.GITHUB_ACTIONS &&
       (await exec(
         `node ./bin/cml-send-github-check.js ${path} --title "${title}" --conclusion "${conclusion}"`
       ));

--- a/bin/cml-tensorboard-dev.js
+++ b/bin/cml-tensorboard-dev.js
@@ -5,16 +5,17 @@ console.log = console.error;
 
 const yargs = require('yargs');
 const fs = require('fs').promises;
-const {spawn} = require('child_process');
-const {homedir} = require('os');
-const {exec} = require('../src/utils');
+const { spawn } = require('child_process');
+const { homedir } = require('os');
+const { exec } = require('../src/utils');
 
-const {handle_error} = process.env.GITHUB_ACTIONS ? require('../src/github')
-                                                  : require('../src/gitlab');
+const { handle_error } = process.env.GITHUB_ACTIONS
+  ? require('../src/github')
+  : require('../src/gitlab');
 
-const {TB_CREDENTIALS} = process.env;
+const { TB_CREDENTIALS } = process.env;
 
-const run = async opts => {
+const run = async (opts) => {
   const {
     md,
     file,
@@ -27,27 +28,27 @@ const run = async opts => {
 
   // set credentials
   const path = `${homedir()}/.config/tensorboard/credentials`;
-  await fs.mkdir(path, {recursive : true});
+  await fs.mkdir(path, { recursive: true });
   await fs.writeFile(`${path}/uploader-creds.json`, credentials);
 
   // launch  tensorboard on background
   const tb_path = await exec('which tensorboard');
   const help = await exec('tensorboard dev upload -h');
   const extra_params_found =
-      (name || description) && help.indexOf('--description') >= 0;
+    (name || description) && help.indexOf('--description') >= 0;
   const extra_params = extra_params_found
-                           ? `--name "${name}" --description "${description}"`
-                           : '';
-  const command =
-      `python -u ${tb_path} dev upload --logdir ${logdir} ${extra_params}`;
+    ? `--name "${name}" --description "${description}"`
+    : '';
+  const command = `python -u ${tb_path} dev upload --logdir ${logdir} ${extra_params}`;
 
-  const proc = spawn(command, {detached : true, shell : true});
+  const proc = spawn(command, { detached: true, shell: true });
 
-  proc.stderr.on('data',
-                 data => { data && console.error(data.toString('utf8')); });
+  proc.stderr.on('data', (data) => {
+    data && console.error(data.toString('utf8'));
+  });
 
   let output = '';
-  proc.stdout.on('data', async data => {
+  proc.stdout.on('data', async (data) => {
     if (data) {
       console.error(data.toString('utf8'));
 
@@ -57,20 +58,17 @@ const run = async opts => {
       if (uri_index > -1) {
         output = output.substring(uri_index, output.length - 1);
 
-        if (md)
-          output = `[${title || name}](${output})`;
+        if (md) output = `[${title || name}](${output})`;
 
-        if (!file)
-          print(output);
-        else
-          await fs.writeFile(file, output);
+        if (!file) print(output);
+        else await fs.writeFile(file, output);
 
         process.exit(0);
       }
     }
   });
 
-  proc.on('exit', code => {
+  proc.on('exit', (code) => {
     console.error(output);
     throw new Error(`Tensorboard process exited with code ${code}`);
   });
@@ -83,21 +81,23 @@ const run = async opts => {
   }, 1 * 60 * 1000);
 };
 
-const argv =
-    yargs.usage(`Usage: $0 <path> --file <string>`)
-        .default('credentials')
-        .alias('c', 'credentials')
-        .default('logdir', '', 'Directory containing the logs to process')
-        .default('name', '', 'Title of the experiment. Max 100 characters.')
-        .default('description', '',
-                 'Experiment description. Markdown format. Max 600 characters.')
-        .default('plugins')
-        .boolean('md')
-        .default('title')
-        .alias('t', 'title')
-        .default('file')
-        .alias('f', 'file')
-        .help('h')
-        .argv;
+const argv = yargs
+  .usage(`Usage: $0 <path> --file <string>`)
+  .default('credentials')
+  .alias('c', 'credentials')
+  .default('logdir', '', 'Directory containing the logs to process')
+  .default('name', '', 'Title of the experiment. Max 100 characters.')
+  .default(
+    'description',
+    '',
+    'Experiment description. Markdown format. Max 600 characters.'
+  )
+  .default('plugins')
+  .boolean('md')
+  .default('title')
+  .alias('t', 'title')
+  .default('file')
+  .alias('f', 'file')
+  .help('h').argv;
 
-run(argv).catch(e => handle_error(e));
+run(argv).catch((e) => handle_error(e));

--- a/bin/cml-tensorboard-dev.js
+++ b/bin/cml-tensorboard-dev.js
@@ -5,15 +5,14 @@ console.log = console.error;
 
 const yargs = require('yargs');
 const fs = require('fs').promises;
-const { spawn } = require('child_process');
-const { homedir } = require('os');
-const { exec } = require('../src/utils');
+const {spawn} = require('child_process');
+const {homedir} = require('os');
+const {exec} = require('../src/utils');
 
-const { handle_error } = process.env.GITHUB_ACTIONS
-  ? require('../src/github')
-  : require('../src/gitlab');
+const {handle_error} = process.env.GITHUB_ACTIONS ? require('../src/github')
+                                                  : require('../src/gitlab');
 
-const { TB_CREDENTIALS } = process.env;
+const {TB_CREDENTIALS} = process.env;
 
 const run = async opts => {
   const {
@@ -28,27 +27,24 @@ const run = async opts => {
 
   // set credentials
   const path = `${homedir()}/.config/tensorboard/credentials`;
-  await fs.mkdir(path, { recursive: true });
+  await fs.mkdir(path, {recursive : true});
   await fs.writeFile(`${path}/uploader-creds.json`, credentials);
 
   // launch  tensorboard on background
   const tb_path = await exec('which tensorboard');
   const help = await exec('tensorboard dev upload -h');
   const extra_params_found =
-    (name || description) && help.indexOf('--description') >= 0;
+      (name || description) && help.indexOf('--description') >= 0;
   const extra_params = extra_params_found
-    ? `--name "${name}" --description "${description}"`
-    : '';
-  const command = `python -u ${tb_path} dev upload --logdir ${logdir} ${extra_params}`;
+                           ? `--name "${name}" --description "${description}"`
+                           : '';
+  const command =
+      `python -u ${tb_path} dev upload --logdir ${logdir} ${extra_params}`;
 
-  const proc = spawn(command, {
-    detached: true,
-    shell: true
-  });
+  const proc = spawn(command, {detached : true, shell : true});
 
-  proc.stderr.on('data', data => {
-    data && console.error(data.toString('utf8'));
-  });
+  proc.stderr.on('data',
+                 data => { data && console.error(data.toString('utf8')); });
 
   let output = '';
   proc.stdout.on('data', async data => {
@@ -61,10 +57,13 @@ const run = async opts => {
       if (uri_index > -1) {
         output = output.substring(uri_index, output.length - 1);
 
-        if (md) output = `[${title || name}](${output})`;
+        if (md)
+          output = `[${title || name}](${output})`;
 
-        if (!file) print(output);
-        else await fs.writeFile(file, output);
+        if (!file)
+          print(output);
+        else
+          await fs.writeFile(file, output);
 
         process.exit(0);
       }
@@ -84,23 +83,21 @@ const run = async opts => {
   }, 1 * 60 * 1000);
 };
 
-const argv = yargs
-  .usage(`Usage: $0 <path> --file <string>`)
-  .default('credentials')
-  .alias('c', 'credentials')
-  .default('logdir', '', 'Directory containing the logs to process')
-  .default('name', '', 'Title of the experiment. Max 100 characters.')
-  .default(
-    'description',
-    '',
-    'Experiment description. Markdown format. Max 600 characters.'
-  )
-  .default('plugins')
-  .boolean('md')
-  .default('title')
-  .alias('t', 'title')
-  .default('file')
-  .alias('f', 'file')
-  .help('h').argv;
+const argv =
+    yargs.usage(`Usage: $0 <path> --file <string>`)
+        .default('credentials')
+        .alias('c', 'credentials')
+        .default('logdir', '', 'Directory containing the logs to process')
+        .default('name', '', 'Title of the experiment. Max 100 characters.')
+        .default('description', '',
+                 'Experiment description. Markdown format. Max 600 characters.')
+        .default('plugins')
+        .boolean('md')
+        .default('title')
+        .alias('t', 'title')
+        .default('file')
+        .alias('f', 'file')
+        .help('h')
+        .argv;
 
 run(argv).catch(e => handle_error(e));

--- a/bin/cml-tensorboard-dev.js
+++ b/bin/cml-tensorboard-dev.js
@@ -9,7 +9,7 @@ const { spawn } = require('child_process');
 const { homedir } = require('os');
 const { exec } = require('../src/utils');
 
-const { handle_error } = process.env.GITHUB_ACTION
+const { handle_error } = process.env.GITHUB_ACTIONS
   ? require('../src/github')
   : require('../src/gitlab');
 

--- a/bin/cml-tensorboard-dev.js
+++ b/bin/cml-tensorboard-dev.js
@@ -15,7 +15,7 @@ const { handle_error } = process.env.GITHUB_ACTIONS
 
 const { TB_CREDENTIALS } = process.env;
 
-const run = async (opts) => {
+const run = async opts => {
   const {
     md,
     file,
@@ -43,12 +43,12 @@ const run = async (opts) => {
 
   const proc = spawn(command, { detached: true, shell: true });
 
-  proc.stderr.on('data', (data) => {
+  proc.stderr.on('data', data => {
     data && console.error(data.toString('utf8'));
   });
 
   let output = '';
-  proc.stdout.on('data', async (data) => {
+  proc.stdout.on('data', async data => {
     if (data) {
       console.error(data.toString('utf8'));
 
@@ -68,7 +68,7 @@ const run = async (opts) => {
     }
   });
 
-  proc.on('exit', (code) => {
+  proc.on('exit', code => {
     console.error(output);
     throw new Error(`Tensorboard process exited with code ${code}`);
   });
@@ -100,4 +100,4 @@ const argv = yargs
   .alias('f', 'file')
   .help('h').argv;
 
-run(argv).catch((e) => handle_error(e));
+run(argv).catch(e => handle_error(e));


### PR DESCRIPTION
According to the docs at https://docs.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables the `GITHUB_ACTIONS` variable shows whether we are running inside and action. `GITHUB_ACTION` (without the plural) would contain the id of the action, which might not always be set (for example first time the action as added in a PR, and not on master). In the case when that variable is not set, commands try to use the gitlab setup erroneously. With this change the command will always find it being run in Github correctly.

Signed-off-by: Gergely Imreh <gergely.imreh@faculty.ai>