### PR TITLE
use GITHUB_ACTIONS to check if running inside a Github Action (#194)

### DIFF
--- a/bin/cml-publish.js
+++ b/bin/cml-publish.js
@@ -8,7 +8,7 @@ const pipe_args = require('../src/pipe-args');
 const yargs = require('yargs');
 const { publish_file } = require('../src/report');
 
-const { handle_error } = process.env.GITHUB_ACTION
+const { handle_error } = process.env.GITHUB_ACTIONS
   ? require('../src/github')
   : require('../src/gitlab');
 

--- a/bin/cml-send-comment.js
+++ b/bin/cml-send-comment.js
@@ -5,7 +5,7 @@ console.log = console.error;
 const fs = require('fs').promises;
 const yargs = require('yargs');
 
-const { head_sha: HEAD_SHA, handle_error, comment } = process.env.GITHUB_ACTION
+const { head_sha: HEAD_SHA, handle_error, comment } = process.env.GITHUB_ACTIONS
   ? require('../src/github')
   : require('../src/gitlab');
 
@@ -14,10 +14,7 @@ const run = async opts => {
   const path = opts._[0];
   const report = await fs.readFile(path, 'utf-8');
 
-  await comment({
-    head_sha,
-    report
-  });
+  await comment({ head_sha, report });
 };
 
 const argv = yargs

--- a/bin/cml-send-comment.test.js
+++ b/bin/cml-send-comment.test.js
@@ -17,7 +17,7 @@ describe('CML e2e', () => {
 
     await fs.writeFile(path, report);
 
-    process.env.GITHUB_ACTION &&
+    process.env.GITHUB_ACTIONS &&
       (await exec(`node ./bin/cml-send-comment.js ${path}`));
 
     await fs.unlink(path);

--- a/bin/cml-send-github-check.js
+++ b/bin/cml-send-github-check.js
@@ -10,7 +10,7 @@ const {
   handle_error,
   create_check_report,
   CHECK_TITLE
-} = process.env.GITHUB_ACTION
+} = process.env.GITHUB_ACTIONS
   ? require('../src/github')
   : require('../src/gitlab');
 
@@ -19,12 +19,7 @@ const run = async opts => {
   const path = opts._[0];
   const report = await fs.readFile(path, 'utf-8');
 
-  await create_check_report({
-    head_sha,
-    report,
-    conclusion,
-    title
-  });
+  await create_check_report({ head_sha, report, conclusion, title });
 };
 
 const argv = yargs

--- a/bin/cml-send-github-check.test.js
+++ b/bin/cml-send-github-check.test.js
@@ -20,7 +20,7 @@ describe('CML e2e', () => {
     const report = `## Test Check Report \n ${img} \n ${pdf}`;
 
     await fs.writeFile(path, report);
-    process.env.GITHUB_ACTION &&
+    process.env.GITHUB_ACTIONS &&
       (await exec(`node ./bin/cml-send-github-check.js ${path}`));
     await fs.unlink(path);
   });
@@ -32,7 +32,7 @@ describe('CML e2e', () => {
     const conclusion = 'neutral';
 
     await fs.writeFile(path, report);
-    process.env.GITHUB_ACTION &&
+    process.env.GITHUB_ACTIONS &&
       (await exec(
         `node ./bin/cml-send-github-check.js ${path} --title "${title}" --conclusion "${conclusion}"`
       ));

--- a/bin/cml-tensorboard-dev.js
+++ b/bin/cml-tensorboard-dev.js
@@ -9,7 +9,7 @@ const { spawn } = require('child_process');
 const { homedir } = require('os');
 const { exec } = require('../src/utils');
 
-const { handle_error } = process.env.GITHUB_ACTION
+const { handle_error } = process.env.GITHUB_ACTIONS
   ? require('../src/github')
   : require('../src/gitlab');
 
@@ -41,10 +41,7 @@ const run = async opts => {
     : '';
   const command = `python -u ${tb_path} dev upload --logdir ${logdir} ${extra_params}`;
 
-  const proc = spawn(command, {
-    detached: true,
-    shell: true
-  });
+  const proc = spawn(command, { detached: true, shell: true });
 
   proc.stderr.on('data', data => {
     data && console.error(data.toString('utf8'));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvcorg/cml",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvcorg/cml",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "author": {
     "name": "DVC",
     "url": "http://cml.dev"


### PR DESCRIPTION
via #194 

According to the docs at https://docs.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables
the `GITHUB_ACTIONS` variable shows whether we are running inside
and action. `GITHUB_ACTION` (without the plural) would contain the
id of the action, which might not always be set (for example
first time the action as added in a PR, and not on master). In
the case when that variable is not set, the commands try to use the
gitlab setup erroneously. With this change the command will
always find it being run in Github correctly.

Signed-off-by: Gergely Imreh <gergely.imreh@faculty.ai>