### PR TITLE
Noninteractive frontend

### DIFF
--- a/.github/workflows/check-container.yml
+++ b/.github/workflows/check-container.yml
@@ -1,9 +1,15 @@
 name: check-container
 
-on: [push]
+
+on:
+  push:
+    branches:
+      - '*'
+      - '!master'
 
 jobs:
   build-container:
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
     runs-on: [ubuntu-18.04]
 
     steps:

--- a/.github/workflows/check-container.yml
+++ b/.github/workflows/check-container.yml
@@ -8,12 +8,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      
+
       - name: Build test image and publish
         run: | 
           echo "${{ secrets.DOCKERHUB_PASSWORD }}" | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
           docker build -t dvcorg/cml-test -f ./docker/Dockerfile .
-          docker publish dvcorg/cml-test
+          docker push dvcorg/cml-test
 
   check-actions:
     needs: build-container

--- a/.github/workflows/check-container.yml
+++ b/.github/workflows/check-container.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: [ubuntu-18.04]
 
     steps:
+      - uses: actions/checkout@v2
+      
       - name: Build test image and publish
         run: | 
           echo "${{ secrets.DOCKERHUB_PASSWORD }}" | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin

--- a/.github/workflows/check-container.yml
+++ b/.github/workflows/check-container.yml
@@ -1,0 +1,26 @@
+name: check-container
+
+on: [push]
+
+jobs:
+  build-container:
+    runs-on: [ubuntu-18.04]
+
+    steps:
+      - name: Build test image and publish
+        run: | 
+          echo "${{ secrets.DOCKERHUB_PASSWORD }}" | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+          docker build -t dvcorg/cml-test -f ./docker/Dockerfile .
+          docker publish dvcorg/cml-test
+
+  check-actions:
+    needs: build-container
+    runs-on: [ubuntu-18.04]
+    container: docker://dvcorg/cml-test
+
+    steps:
+      - uses: r-lib/actions/setup-r@master
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,6 +8,8 @@ LABEL maintainer="dvc.org"
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends --fix-missing \
+        sudo\ 
+        tzdata \
         build-essential \
         apt-utils \
         apt-transport-https \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,8 +6,11 @@ FROM nvidia/cuda${ARCH:+-$ARCH}:${CUDA}-base-ubuntu${UBUNTU_VERSION} as base
 
 LABEL maintainer="dvc.org"
 
+ENV DEBIAN_FRONTEND=noninteractive
+RUN echo "APT::Get::Assume-Yes \"true\";" > /etc/apt/apt.conf.d/90assumeyes
+
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends --fix-missing \
+    apt-get install --no-install-recommends --fix-missing \
         sudo\ 
         tzdata \
         build-essential \
@@ -88,16 +91,7 @@ RUN apt update && \
     ldconfig
 # TENSORFLOW ENDS
 
-# DOCKER, OUR CUSTOM DOCKER MACHINE FORK, GITLAB RUNNER AND GITHUB RUNNER
-# OUR DOCKER_MACHINE FORK SUPPORTS GPU ACCELARATOR
-ENV RUNNER_PATH=/home/runner
-ENV RUNNER_ALLOW_RUNASROOT=1
-
-# FIXES Python setup Action
-RUN mkdir /__t
-RUN ln -s /__t /opt/hostedtoolcache
-ENV AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache
-
+# DOCKER, OUR CUSTOM DOCKER MACHINE FORK THAT SUPPORTS GPU ACCELARATOR
 RUN curl -fsSL https://get.docker.com -o get-docker.sh && sh get-docker.sh && \
     curl -L "https://github.com/docker/compose/releases/download/1.24.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \
     chmod +x /usr/local/bin/docker-compose && \
@@ -106,6 +100,16 @@ RUN curl -fsSL https://get.docker.com -o get-docker.sh && sh get-docker.sh && \
     mv $(go env GOPATH)/src/github.com/iterative $(go env GOPATH)/src/github.com/docker && \
     cd $(go env GOPATH)/src/github.com/docker/machine && make build && \
     ln -s $(go env GOPATH)/src/github.com/docker/machine/bin/docker-machine /usr/local/bin/docker-machine
+
+
+# GITLAB RUNNER AND GITHUB RUNNER
+ENV RUNNER_PATH=/home/runner
+ENV RUNNER_ALLOW_RUNASROOT=1
+
+# FIXES Python setup Action
+RUN mkdir /__t
+RUN ln -s /__t /opt/hostedtoolcache
+ENV AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache
 
 RUN mkdir ${RUNNER_PATH}
 WORKDIR ${RUNNER_PATH}


### PR DESCRIPTION
Pain point: Some actions are using sudo and in some cases installing packages that must be unattended due to the CI workflow nature as [manifested by some users](https://discord.com/channels/485586884165107732/728693131557732403/742122480876912660). Having inspected that the GH ubuntu 18.04 image is dealing with such scenarios this is the solution:

This PR setup a non interactive Debian frontend, ```sudo``` command and image tests with real GH actions in our docker image cml and successors.