### PR TITLE
Docker layer cache

### DIFF
--- a/.github/workflows/check-container.yml
+++ b/.github/workflows/check-container.yml
@@ -15,9 +15,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: satackey/action-docker-layer-caching@v0.0.8
+
       - name: Build test image and publish
         run: | 
           echo "${{ secrets.DOCKERHUB_PASSWORD }}" | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+
+          docker build -t dvcorg/cml -f ./docker/Dockerfile .
+          docker build -t dvcorg/cml-py3 -f ./docker/Dockerfile-py3 .
+
           docker build -t dvcorg/cml-test -f ./docker/Dockerfile .
           docker push dvcorg/cml-test
 

--- a/.github/workflows/check-container.yml
+++ b/.github/workflows/check-container.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: satackey/action-docker-layer-caching@v0.0.8
+      # - uses: satackey/action-docker-layer-caching@v0.0.8
 
       - name: Build test image and publish
         run: | 

--- a/.github/workflows/check-container.yml
+++ b/.github/workflows/check-container.yml
@@ -30,7 +30,7 @@ jobs:
   check-actions:
     needs: build-container
     runs-on: [ubuntu-18.04]
-    container: docker://dvcorg/cml-test
+    container: dvcorg/cml-test
 
     steps:
       - uses: r-lib/actions/setup-r@master


### PR DESCRIPTION
This PR introduces docker layer cache. The main goal is to accelerate the use of CML images making Github caching the layers, however looks like the cache is only effective from the repository. Worst case scenario is at least accelerate the ```check-container``` workflow test and the process of building CML images.