### PR TITLE
Hotfix octokit broken createRegistrationToken

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvcorg/cml",
-  "version": "0.1.37",
+  "version": "0.1.39",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvcorg/cml",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "author": {
     "name": "DVC",
     "url": "http://cml.dev"

--- a/src/github.js
+++ b/src/github.js
@@ -64,7 +64,7 @@ const comment = async (opts) => {
 const get_runner_token = async () => {
   const {
     data: { token }
-  } = await octokit.actions.createRegistrationToken({
+  } = await octokit.actions.createRegistrationTokenForRepo({
     owner,
     repo
   });


### PR DESCRIPTION
Octokit has broken createRegistrationToken despite that its on the docs creating createRegistrationTokenForRep and createRegistrationTokenForOrg.

This is a hotfix to currenly fix image latest which is broken