### PR TITLE
hotfix:"head_sha" wasn't supplied

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvcorg/cml",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvcorg/cml",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "author": {
     "name": "DVC",
     "url": "http://cml.dev"

--- a/src/github.js
+++ b/src/github.js
@@ -85,7 +85,7 @@ exports.is_pr = IS_PR;
 exports.ref = REF;
 exports.head_sha =
   GITHUB_EVENT_NAME === 'pull_request'
-    ? github.context.payload.after
+    ? github.context.payload.pull_request.head.sha
     : HEAD_SHA;
 exports.user_email = USER_EMAIL;
 exports.user_name = USER_NAME;


### PR DESCRIPTION
#236 was fixed pointing a variable that does not exist in the first pull_request but in all the rest making the code to fail if the ```pull_request``` is the very first.

This PR fixes that pointing to a right place.