### PR TITLE
Gitlab uploads in cml-publish

### DIFF
--- a/bin/cml-publish.js
+++ b/bin/cml-publish.js
@@ -32,7 +32,7 @@ const run = async (opts) => {
     gitlab_uploads = false;
   }
 
-  const output = await publish_file({ buffer, path, ...opts });
+  const output = await publish_file({ buffer, path, gitlab_uploads, ...opts });
 
   if (!file) print(output);
   else await fs.writeFile(file, output);

--- a/bin/cml-publish.js
+++ b/bin/cml-publish.js
@@ -15,7 +15,8 @@ const { handle_error } = GITHUB_ACTIONS
   : require('../src/gitlab');
 
 const run = async (opts) => {
-  const { data, md, title, 'gitlab-uploads': gitlab_uploads, file } = opts;
+  const { data, file } = opts;
+  let { 'gitlab-uploads': gitlab_uploads } = opts;
   const path = opts._[0];
 
   let buffer;
@@ -27,9 +28,11 @@ const run = async (opts) => {
     * gitlab_uploads is only for gitlab!    *
     * ***************************************
     `);
+
+    gitlab_uploads = false;
   }
 
-  const output = await publish_file({ path, buffer, md, title });
+  const output = await publish_file({ buffer, path, ...opts });
 
   if (!file) print(output);
   else await fs.writeFile(file, output);

--- a/bin/cml-publish.js
+++ b/bin/cml-publish.js
@@ -24,9 +24,9 @@ const run = async (opts) => {
 
   if (GITHUB_ACTIONS && gitlab_uploads) {
     console.error(`
-    *****************************************
-    * gitlab_uploads is only for gitlab!    *
-    * ***************************************
+    *********************************************
+    * gitlab-uploads option is only for gitlab! *
+    * *******************************************
     `);
 
     gitlab_uploads = false;

--- a/bin/cml-publish.js
+++ b/bin/cml-publish.js
@@ -43,11 +43,17 @@ const data = pipe_args.piped_arg();
 const argv = yargs
   .usage(`Usage: $0 <path> --file <string>`)
   .boolean('md')
+  .describe('Output in markdown.')
   .default('title')
+  .describe(
+    'If --md sets the title in markdown [title](url) or ![](url title).'
+  )
   .alias('t', 'title')
   .default('file')
+  .describe('Outputs to the given file.')
   .alias('f', 'file')
   .boolean('gitlab-uploads')
+  .describe("Uses Gitlab's uploads api instead of CML's storage.")
   .help('h')
   .demand(data ? 0 : 1).argv;
 run({ ...argv, data }).catch((e) => handle_error(e));

--- a/bin/cml-publish.js
+++ b/bin/cml-publish.js
@@ -43,17 +43,21 @@ const data = pipe_args.piped_arg();
 const argv = yargs
   .usage(`Usage: $0 <path> --file <string>`)
   .boolean('md')
-  .describe('Output in markdown.')
+  .describe('md', 'Output in markdown.')
   .default('title')
   .describe(
+    'title',
     'If --md sets the title in markdown [title](url) or ![](url title).'
   )
-  .alias('t', 'title')
+  .alias('title', 't')
   .default('file')
-  .describe('Outputs to the given file.')
-  .alias('f', 'file')
+  .describe('file', 'Outputs to the given file.')
+  .alias('file', 'f')
   .boolean('gitlab-uploads')
-  .describe("Uses Gitlab's uploads api instead of CML's storage.")
+  .describe(
+    'gitlab-uploads',
+    "Uses Gitlab's uploads api instead of CML's storage."
+  )
   .help('h')
   .demand(data ? 0 : 1).argv;
 run({ ...argv, data }).catch((e) => handle_error(e));

--- a/bin/cml-publish.test.js
+++ b/bin/cml-publish.test.js
@@ -11,14 +11,13 @@ describe('CML e2e', () => {
       "Usage: cml-publish.js <path> --file <string>
 
       Options:
-        --version                                 Show version number        [boolean]
-        --Output in markdown.
-        --If --md sets the title in markdown
-        [title](url) or ![](url title).
-        --Outputs to the given file.
-        --Uses Gitlab's uploads api instead of
-        CML's storage.
-        -h                                        Show help                  [boolean]"
+        --version         Show version number                                [boolean]
+        --md              Output in markdown.                                [boolean]
+        --title, -t       If --md sets the title in markdown [title](url) or ![](url
+                          title).
+        --file, -f        Outputs to the given file.
+        --gitlab-uploads  Uses Gitlab's uploads api instead of CML's storage.[boolean]
+        -h                Show help                                          [boolean]"
     `);
   });
 

--- a/bin/cml-publish.test.js
+++ b/bin/cml-publish.test.js
@@ -38,27 +38,31 @@ describe('CML e2e', () => {
   });
 
   test('cml-publish assets/logo.pdf --md', async () => {
+    const title = 'this is awesome';
     const output = await exec(
-      `echo none | node ./bin/cml-publish.js assets/logo.pdf --md --title 'this is awesome'`
+      `echo none | node ./bin/cml-publish.js assets/logo.pdf --md --title '${title}'`
     );
 
-    expect(output.startsWith('[this is awesome](')).toBe(true);
+    expect(output.startsWith(`[${title}](`)).toBe(true);
   });
 
   test('cml-publish assets/logo.pdf', async () => {
     const output = await exec(
-      `echo none | node ./bin/cml-publish.js assets/logo.pdf --title 'this is awesome'`
+      `echo none | node ./bin/cml-publish.js assets/logo.pdf`
     );
 
     expect(output.startsWith('https://')).toBe(true);
   });
 
   test('cml-publish assets/test.svg --md', async () => {
+    const title = 'this is awesome';
     const output = await exec(
-      `echo none | node ./bin/cml-publish.js assets/test.svg --md --title 'this is awesome'`
+      `echo none | node ./bin/cml-publish.js assets/test.svg --md --title '${title}'`
     );
 
-    expect(output.startsWith('![](')).toBe(true);
+    expect(output.startsWith('![](') && output.endsWith(`${title})`)).toBe(
+      true
+    );
   });
 
   test('cml-publish assets/test.svg', async () => {
@@ -73,18 +77,7 @@ describe('CML e2e', () => {
     const file = `cml-publish-test.md`;
 
     await exec(
-      `echo none | node ./bin/cml-publish.js assets/logo.pdf --title 'this is awesome' --file ${file}`
-    );
-
-    expect(fs.existsSync(file)).toBe(true);
-    await fs.promises.unlink(file);
-  });
-
-  test('cml-publish assets/logo.pdf to gitlab uploads', async () => {
-    const file = `cml-publish-test.md`;
-
-    await exec(
-      `echo none | node ./bin/cml-publish.js assets/logo.pdf --title 'this is awesome' --file ${file} --gitlab-uploads`
+      `echo none | node ./bin/cml-publish.js assets/logo.pdf --file ${file}`
     );
 
     expect(fs.existsSync(file)).toBe(true);

--- a/bin/cml-publish.test.js
+++ b/bin/cml-publish.test.js
@@ -11,8 +11,14 @@ describe('CML e2e', () => {
       "Usage: cml-publish.js <path> --file <string>
 
       Options:
-        --version  Show version number                                       [boolean]
-        -h         Show help                                                 [boolean]"
+        --version                                 Show version number        [boolean]
+        --Output in markdown.
+        --If --md sets the title in markdown
+        [title](url) or ![](url title).
+        --Outputs to the given file.
+        --Uses Gitlab's uploads api instead of
+        CML's storage.
+        -h                                        Show help                  [boolean]"
     `);
   });
 

--- a/bin/cml-publish.test.js
+++ b/bin/cml-publish.test.js
@@ -60,7 +60,7 @@ describe('CML e2e', () => {
       `echo none | node ./bin/cml-publish.js assets/test.svg --md --title '${title}'`
     );
 
-    expect(output.startsWith('![](') && output.endsWith(`${title})`)).toBe(
+    expect(output.startsWith('![](') && output.endsWith(`${title}")`)).toBe(
       true
     );
   });

--- a/bin/cml-publish.test.js
+++ b/bin/cml-publish.test.js
@@ -74,4 +74,15 @@ describe('CML e2e', () => {
     expect(fs.existsSync(file)).toBe(true);
     await fs.promises.unlink(file);
   });
+
+  test('cml-publish assets/logo.pdf to gitlab uploads', async () => {
+    const file = `cml-publish-test.md`;
+
+    await exec(
+      `echo none | node ./bin/cml-publish.js assets/logo.pdf --title 'this is awesome' --file ${file} --gitlab-uploads`
+    );
+
+    expect(fs.existsSync(file)).toBe(true);
+    await fs.promises.unlink(file);
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvcorg/cml",
-  "version": "0.1.45",
+  "version": "0.1.46",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -985,8 +985,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
       "version": "2.1.2",
@@ -1529,7 +1528,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -1772,8 +1770,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "deprecation": {
       "version": "2.3.1",
@@ -2642,6 +2639,16 @@
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
+    },
+    "form-data": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+      "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -5324,14 +5331,12 @@
     "mime-db": {
       "version": "1.44.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
-      "dev": true
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
     },
     "mime-types": {
       "version": "2.1.27",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
       "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
-      "dev": true,
       "requires": {
         "mime-db": "1.44.0"
       }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   "dependencies": {
     "@actions/github": "^4.0.0",
     "file-type": "^14.2.0",
+    "form-data": "^3.0.0",
     "is-svg": "^4.2.1",
     "node-fetch": "^2.6.0",
     "node-ssh": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvcorg/cml",
-  "version": "0.1.45",
+  "version": "0.1.46",
   "author": {
     "name": "DVC",
     "url": "http://cml.dev"

--- a/src/gitlab.js
+++ b/src/gitlab.js
@@ -1,6 +1,8 @@
 const fetch = require('node-fetch');
 const { URLSearchParams } = require('url');
 
+const { fetch_upload_data } = require('./utils');
+
 const {
   CI_API_V4_URL,
   CI_PROJECT_PATH = '',
@@ -38,6 +40,7 @@ const get_runner_token = async () => {
   const endpoint = `${CI_API_V4_URL}/projects/${encodeURIComponent(
     CI_PROJECT_PATH
   )}`;
+
   const headers = { 'PRIVATE-TOKEN': TOKEN, Accept: 'application/json' };
   const response = await fetch(endpoint, { method: 'GET', headers });
   const project = await response.json();
@@ -48,8 +51,6 @@ const get_runner_token = async () => {
 const register_runner = async (opts) => {
   const endpoint = `${CI_API_V4_URL}/runners`;
 
-  const headers = { 'PRIVATE-TOKEN': TOKEN, Accept: 'application/json' };
-
   const body = new URLSearchParams();
   body.append('token', opts.token);
   body.append('locked', 'true');
@@ -57,10 +58,31 @@ const register_runner = async (opts) => {
   body.append('access_level', 'not_protected');
   body.append('tag_list', opts.tags);
 
+  const headers = { 'PRIVATE-TOKEN': TOKEN, Accept: 'application/json' };
   const response = await fetch(endpoint, { method: 'POST', headers, body });
   const runner = await response.json();
 
   return runner;
+};
+
+const upload = async (opts) => {
+  const endpoint = `${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/uploads`;
+
+  const { headers: fetch_headers, body } = await fetch_upload_data({
+    ...opts,
+    file_var: 'filename'
+  });
+  const { 'Content-Type': mime, 'Content-length': size } = fetch_headers;
+
+  const headers = {
+    'PRIVATE-TOKEN': TOKEN,
+    Accept: 'application/json',
+    ...fetch_headers
+  };
+  const response = await fetch(endpoint, { method: 'POST', headers, body });
+  const { url: uri } = await response.json();
+
+  return { uri, mime, size };
 };
 
 const handle_error = (e) => {
@@ -76,6 +98,7 @@ exports.user_name = USER_NAME;
 exports.comment = comment;
 exports.get_runner_token = get_runner_token;
 exports.register_runner = register_runner;
+exports.upload = upload;
 exports.handle_error = handle_error;
 
 exports.CHECK_TITLE = 'CML Report';

--- a/src/gitlab.js
+++ b/src/gitlab.js
@@ -1,7 +1,6 @@
 const fetch = require('node-fetch');
 const FormData = require('form-data');
 const { URLSearchParams } = require('url');
-const fs = require('fs');
 
 const { fetch_upload_data } = require('./utils');
 
@@ -69,17 +68,12 @@ const register_runner = async (opts) => {
 };
 
 const upload = async (opts) => {
-  const { path, buffer } = opts;
   const endpoint = `${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/uploads`;
 
-  const { headers: fetch_headers } = await fetch_upload_data({
-    ...opts,
-    file_var: 'filename'
-  });
-  const { 'Content-Type': mime, 'Content-length': size } = fetch_headers;
+  const { size, mime, data } = await fetch_upload_data(opts);
 
   const body = new FormData();
-  body.append('file', path ? fs.createReadStream(path) : buffer);
+  body.append('file', data);
 
   const headers = { 'PRIVATE-TOKEN': TOKEN, Accept: 'application/json' };
   const response = await fetch(endpoint, { method: 'POST', headers, body });

--- a/src/gitlab.js
+++ b/src/gitlab.js
@@ -68,7 +68,8 @@ const register_runner = async (opts) => {
 };
 
 const upload = async (opts) => {
-  const { path } = opts;
+  const { path, buffer } = opts;
+  console.log(path);
   const endpoint = `${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/uploads`;
 
   const { headers: fetch_headers } = await fetch_upload_data({
@@ -77,11 +78,11 @@ const upload = async (opts) => {
   });
   const { 'Content-Type': mime, 'Content-length': size } = fetch_headers;
 
-  const form = new FormData();
-  form.append('file', fs.createReadStream(path));
+  const body = new FormData();
+  body.append('file', path ? fs.createReadStream(path) : buffer);
 
   const headers = { 'PRIVATE-TOKEN': TOKEN, Accept: 'application/json' };
-  const response = await fetch(endpoint, { method: 'POST', headers, form });
+  const response = await fetch(endpoint, { method: 'POST', headers, body });
   const json = await response.json();
 
   console.log(json);

--- a/src/gitlab.js
+++ b/src/gitlab.js
@@ -78,11 +78,13 @@ const upload = async (opts) => {
   const { 'Content-Type': mime, 'Content-length': size } = fetch_headers;
 
   const form = new FormData();
-  form.append('file', path ? fs.createReadStream('/foo/bar.jpg') : buffer);
+  form.append('file', path ? fs.createReadStream(path) : buffer);
 
   const headers = { 'PRIVATE-TOKEN': TOKEN, Accept: 'application/json' };
   const response = await fetch(endpoint, { method: 'POST', headers, form });
   const json = await response.json();
+
+  console.log(json);
 
   return { uri: json.url, mime, size };
 };

--- a/src/gitlab.js
+++ b/src/gitlab.js
@@ -1,6 +1,6 @@
 const fetch = require('node-fetch');
 const FormData = require('form-data');
-const { URLSearchParams, URL } = require('url');
+const { URLSearchParams } = require('url');
 const fs = require('fs');
 
 const { fetch_upload_data } = require('./utils');
@@ -15,7 +15,7 @@ const {
   GITLAB_USER_EMAIL,
   GITLAB_USER_NAME,
   GITLAB_TOKEN,
-  CI_REPOSITORY_URL,
+  CI_PROJECT_URL,
   repo_token
 } = process.env;
 
@@ -84,9 +84,8 @@ const upload = async (opts) => {
   const headers = { 'PRIVATE-TOKEN': TOKEN, Accept: 'application/json' };
   const response = await fetch(endpoint, { method: 'POST', headers, body });
   const { url } = await response.json();
-  const { host } = new URL(CI_REPOSITORY_URL);
 
-  return { uri: `${host}/${url}`, mime, size };
+  return { uri: `${CI_PROJECT_URL}${url}`, mime, size };
 };
 
 const handle_error = (e) => {

--- a/src/gitlab.js
+++ b/src/gitlab.js
@@ -1,6 +1,6 @@
 const fetch = require('node-fetch');
 const FormData = require('form-data');
-const { URLSearchParams } = require('url');
+const { URLSearchParams, URL } = require('url');
 const fs = require('fs');
 
 const { fetch_upload_data } = require('./utils');
@@ -15,6 +15,7 @@ const {
   GITLAB_USER_EMAIL,
   GITLAB_USER_NAME,
   GITLAB_TOKEN,
+  CI_REPOSITORY_URL,
   repo_token
 } = process.env;
 
@@ -69,7 +70,6 @@ const register_runner = async (opts) => {
 
 const upload = async (opts) => {
   const { path, buffer } = opts;
-  console.log(path);
   const endpoint = `${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/uploads`;
 
   const { headers: fetch_headers } = await fetch_upload_data({
@@ -83,11 +83,10 @@ const upload = async (opts) => {
 
   const headers = { 'PRIVATE-TOKEN': TOKEN, Accept: 'application/json' };
   const response = await fetch(endpoint, { method: 'POST', headers, body });
-  const json = await response.json();
+  const { url } = await response.json();
+  const { host } = new URL(CI_REPOSITORY_URL);
 
-  console.log(json);
-
-  return { uri: json.url, mime, size };
+  return { uri: `${host}/${url}`, mime, size };
 };
 
 const handle_error = (e) => {

--- a/src/gitlab.js
+++ b/src/gitlab.js
@@ -68,7 +68,7 @@ const register_runner = async (opts) => {
 };
 
 const upload = async (opts) => {
-  const { path, buffer } = opts;
+  const { path } = opts;
   const endpoint = `${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/uploads`;
 
   const { headers: fetch_headers } = await fetch_upload_data({
@@ -78,7 +78,7 @@ const upload = async (opts) => {
   const { 'Content-Type': mime, 'Content-length': size } = fetch_headers;
 
   const form = new FormData();
-  form.append('file', path ? fs.createReadStream(path) : buffer);
+  form.append('file', fs.createReadStream(path));
 
   const headers = { 'PRIVATE-TOKEN': TOKEN, Accept: 'application/json' };
   const response = await fetch(endpoint, { method: 'POST', headers, form });

--- a/src/report.js
+++ b/src/report.js
@@ -7,12 +7,12 @@ const publish_file = async (opts) => {
   let mime, uri;
 
   if (gitlab_uploads) {
-    ({ mime, uri } = await gl_upload({ opts }));
+    ({ mime, uri } = await gl_upload(opts));
   } else {
-    ({ mime, uri } = await upload({ opts }));
+    ({ mime, uri } = await upload(opts));
   }
 
-  if (md && mime.matches('(image|video)/.*'))
+  if (md && mime.match('(image|video)/.*'))
     return `![](${uri}${title ? ` "${title}"` : ''})`;
   if (md) return `[${title}](${uri})`;
 

--- a/src/report.js
+++ b/src/report.js
@@ -1,10 +1,18 @@
 const { upload } = require('./utils');
+const { upload: gl_upload } = require('./gitlab');
 
 const publish_file = async (opts) => {
-  const { md = false, title = '' } = opts;
-  const { mime, uri } = await upload({ ...opts });
+  const { md = false, title = '', gitlab_uploads } = opts;
 
-  if (md && mime.startsWith('image/'))
+  let mime, uri;
+
+  if (gitlab_uploads) {
+    ({ mime, uri } = await gl_upload({ opts }));
+  } else {
+    ({ mime, uri } = await upload({ opts }));
+  }
+
+  if (md && mime.matches('(image|video)/.*'))
     return `![](${uri}${title ? ` "${title}"` : ''})`;
   if (md) return `[${title}](${uri})`;
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -52,9 +52,8 @@ const mime_type = async (opts) => {
   }
 };
 
-const upload = async (opts) => {
-  const { path, buffer } = opts;
-  const endpoint = 'https://asset.cml.dev';
+const fetch_upload_data = async (opts) => {
+  const { path, buffer, file_var = 'file' } = opts;
   const mime = await mime_type(opts);
 
   let body;
@@ -74,12 +73,24 @@ const upload = async (opts) => {
   const headers = {
     'Content-length': size,
     'Content-Type': mime,
-    'Content-Disposition': `inline; filename="${filename}"`
+    'Content-Disposition': `inline; ${file_var}="${filename}"`
   };
+
+  return { headers, body };
+};
+
+const upload = async (opts) => {
+  const endpoint = 'https://asset.cml.dev';
+
+  const { headers, body } = await fetch_upload_data({
+    ...opts,
+    file_var: 'filename'
+  });
+  const { 'Content-Type': mime, 'Content-length': size } = headers;
   const response = await fetch(endpoint, { method: 'POST', headers, body });
   const uri = await response.text();
 
-  return { mime, size, uri };
+  return { uri, mime, size };
 };
 
 const randid = () => {
@@ -96,6 +107,7 @@ const sleep = (secs) => {
 };
 
 exports.exec = exec;
+exports.fetch_upload_data = fetch_upload_data;
 exports.upload = upload;
 exports.randid = randid;
 exports.sleep = sleep;


### PR DESCRIPTION
This PR introduces ```--gitlab-uploads``` in ```cml-publish``` command. 

When specified CML will use GL's uploads api, which is similar to ours but is not constrained by size. 
If used in a GH repo it will show a warning and will fallback to our api.


closes #233 

