### PR TITLE
Add support for Github organisation level runners

### DIFF
--- a/src/github.js
+++ b/src/github.js
@@ -74,15 +74,13 @@ const get_runner_token = async () => {
     return token;
   }
 
-  if (typeof repo === 'undefined') {
-    const {
-      data: { token }
-    } = await octokit.actions.createRegistrationTokenForOrg({
-      org
-    });
+  const {
+    data: { token }
+  } = await octokit.actions.createRegistrationTokenForOrg({
+    org
+  });
 
-    return token;
-  }
+  return token;
 };
 
 const register_runner = async (opts) => {

--- a/src/github.js
+++ b/src/github.js
@@ -11,6 +11,7 @@ const {
 } = process.env;
 
 const [owner, repo] = GITHUB_REPOSITORY.split('/');
+const org = owner;
 const IS_PR = GITHUB_EVENT_NAME === 'pull_request';
 const REF = IS_PR ? GITHUB_HEAD_REF : GITHUB_REF;
 const HEAD_SHA = GITHUB_SHA;
@@ -62,14 +63,26 @@ const comment = async (opts) => {
 };
 
 const get_runner_token = async () => {
-  const {
-    data: { token }
-  } = await octokit.actions.createRegistrationTokenForRepo({
-    owner,
-    repo
-  });
+  if (typeof owner !== 'undefined' && typeof repo !== 'undefined') {
+    const {
+      data: { token }
+    } = await octokit.actions.createRegistrationTokenForRepo({
+      owner,
+      repo
+    });
 
-  return token;
+    return token;
+  }
+
+  if (typeof owner !== 'undefined' && typeof repo === 'undefined') {
+    const {
+      data: { token }
+    } = await octokit.actions.createRegistrationTokenForOrg({
+      org
+    });
+
+    return token;
+  }
 };
 
 const register_runner = async (opts) => {

--- a/src/github.js
+++ b/src/github.js
@@ -63,7 +63,7 @@ const comment = async (opts) => {
 };
 
 const get_runner_token = async () => {
-  if (typeof owner !== 'undefined' && typeof repo !== 'undefined') {
+  if (typeof repo !== 'undefined') {
     const {
       data: { token }
     } = await octokit.actions.createRegistrationTokenForRepo({
@@ -74,7 +74,7 @@ const get_runner_token = async () => {
     return token;
   }
 
-  if (typeof owner !== 'undefined' && typeof repo === 'undefined') {
+  if (typeof repo === 'undefined') {
     const {
       data: { token }
     } = await octokit.actions.createRegistrationTokenForOrg({


### PR DESCRIPTION
This PR adds support for organisation level runner registration in Github, you are able to register a runner that can be used by multiple repositories.