### PR TITLE
RUNNER_IDLE_TIMEOUT 0 is forever

### DIFF
--- a/bin/cml-cloud-runner-entrypoint.js
+++ b/bin/cml-cloud-runner-entrypoint.js
@@ -106,6 +106,7 @@ process.on('SIGQUIT', shutdown);
 
 const run = async () => {
   RUNNER_TOKEN = await get_runner_token();
+
   if (!RUNNER_TOKEN) {
     throw new Error(
       'RUNNER_TOKEN is needed to start the runner. Are you setting a runner?'
@@ -182,6 +183,7 @@ const run = async () => {
 
   const watcher = setInterval(() => {
     IS_GITHUB &&
+      RUNNER_IDLE_TIMEOUT !== 0 &&
       TIMEOUT_TIMER >= RUNNER_IDLE_TIMEOUT &&
       shutdown() &&
       clearInterval(watcher);


### PR DESCRIPTION
This PR disables the idle timeout on Github runners so that they can run indefinitely.