### PR TITLE
Fix GitLab runner not using RUNNER_REPO_ORIGIN

### DIFF
--- a/bin/cml-cloud-runner-entrypoint.js
+++ b/bin/cml-cloud-runner-entrypoint.js
@@ -138,7 +138,7 @@ const run = async () => {
     GITLAB_CI_TOKEN = runner.token;
 
     command = `gitlab-runner --log-format="json" run-single \
-      --url "https://gitlab.com/" \
+      --url "${RUNNER_REPO_ORIGIN}" \
       --token "${runner.token}" \
       --executor "${RUNNER_EXECUTOR}" \
       --docker-runtime "${RUNNER_RUNTIME}" \


### PR DESCRIPTION
This PR:
- Make GitLab runner execute using the `RUNNER_REPO_ORIGIN` fixing error when starting runner for self-hosted GitLab

Fixes #292 