### PR TITLE
Support GitHub Enterprise

### DIFF
--- a/src/cml.js
+++ b/src/cml.js
@@ -46,7 +46,7 @@ const infer_token = () => {
 
 const infer_options = () => {
   const { GITHUB_BASE_URL } = process.env;
-  options = {};
+  const options = {};
 
   if (GITHUB_BASE_URL) options.baseUrl = GITHUB_BASE_URL;
 

--- a/src/cml.js
+++ b/src/cml.js
@@ -30,10 +30,10 @@ const infer_driver = (opts = {}) => {
 };
 
 const get_driver = (opts) => {
-  const { driver, repo, token } = opts;
+  const { driver, repo, token, options } = opts;
   if (!driver) throw new Error('driver not set');
 
-  if (driver === 'github') return new Github({ repo, token });
+  if (driver === 'github') return new Github({ repo, token, options });
   if (driver === 'gitlab') return new Gitlab({ repo, token });
 
   throw new Error(`driver ${driver} unknown!`);
@@ -44,6 +44,15 @@ const infer_token = () => {
   return repo_token || GITHUB_TOKEN || GITLAB_TOKEN;
 };
 
+const infer_options = () => {
+  const { GITHUB_BASE_URL } = process.env;
+  options = {};
+
+  if (GITHUB_BASE_URL) options.baseUrl = GITHUB_BASE_URL;
+
+  return options;
+};
+
 class CML {
   constructor(opts = {}) {
     const { driver, repo, token } = opts;
@@ -51,6 +60,7 @@ class CML {
     this.repo = uri_no_trailing_slash(repo || repo_from_origin());
     this.token = token || infer_token();
     this.driver = driver || infer_driver({ repo: this.repo });
+    this.options = infer_options();
   }
 
   async head_sha() {

--- a/src/cml.js
+++ b/src/cml.js
@@ -30,10 +30,10 @@ const infer_driver = (opts = {}) => {
 };
 
 const get_driver = (opts) => {
-  const { driver, repo, token, options } = opts;
+  const { driver, repo, token } = opts;
   if (!driver) throw new Error('driver not set');
 
-  if (driver === 'github') return new Github({ repo, token, options });
+  if (driver === 'github') return new Github({ repo, token });
   if (driver === 'gitlab') return new Gitlab({ repo, token });
 
   throw new Error(`driver ${driver} unknown!`);
@@ -44,15 +44,6 @@ const infer_token = () => {
   return repo_token || GITHUB_TOKEN || GITLAB_TOKEN;
 };
 
-const infer_options = () => {
-  const { GITHUB_BASE_URL } = process.env;
-  const options = {};
-
-  if (GITHUB_BASE_URL) options.baseUrl = GITHUB_BASE_URL;
-
-  return options;
-};
-
 class CML {
   constructor(opts = {}) {
     const { driver, repo, token } = opts;
@@ -60,7 +51,6 @@ class CML {
     this.repo = uri_no_trailing_slash(repo || repo_from_origin());
     this.token = token || infer_token();
     this.driver = driver || infer_driver({ repo: this.repo });
-    this.options = infer_options();
   }
 
   async head_sha() {

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -17,21 +17,22 @@ const owner_repo = (opts) => {
   return { owner, repo };
 };
 
-const octokit = (token) => {
+const octokit = (token, octokitOptions) => {
   if (!token) throw new Error('token not found');
 
-  return github.getOctokit(token);
+  return github.getOctokit(token, octokitOptions);
 };
 
 class Github {
   constructor(opts = {}) {
-    const { repo, token } = opts;
+    const { repo, token, options } = opts;
 
     if (!repo) throw new Error('repo not found');
     if (!token) throw new Error('token not found');
 
     this.repo = repo;
     this.token = token;
+    this.octokitOptions = options;
   }
 
   owner_repo(opts = {}) {
@@ -43,7 +44,8 @@ class Github {
     const { report: body, commit_sha } = opts;
 
     const { url: commit_url } = await octokit(
-      this.token
+      this.token,
+      this.octokitOptions
     ).repos.createCommitComment({
       ...owner_repo({ uri: this.repo }),
       body,
@@ -65,7 +67,7 @@ class Github {
     } = opts;
 
     const name = title;
-    return await octokit(this.token).checks.create({
+    return await octokit(this.token, this.octokitOptions).checks.create({
       ...owner_repo({ uri: this.repo }),
       head_sha,
       started_at,
@@ -83,7 +85,7 @@ class Github {
 
   async runner_token() {
     const { owner, repo } = owner_repo({ uri: this.repo });
-    const { actions } = octokit(this.token);
+    const { actions } = octokit(this.token, this.octokitOptions);
 
     if (typeof repo !== 'undefined') {
       const {

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -18,8 +18,18 @@ const owner_repo = (opts) => {
   return { owner, repo };
 };
 
-const octokit = (token, octokit_options) => {
+const octokit = (token, repo) => {
   if (!token) throw new Error('token not found');
+
+  const octokit_options = {};
+
+  if (!repo.includes('github.com')) {
+    // GitHub Enterprise, use the: repo URL host + '/api/v3' - as baseURL
+    //  as per: https://developer.github.com/enterprise/v3/enterprise-admin/#endpoint-urls
+    const repo_url = new url.URL(repo);
+
+    octokit_options.baseUrl = 'https://' + repo_url.host + '/api/v3';
+  }
 
   return github.getOctokit(token, octokit_options);
 };
@@ -33,13 +43,6 @@ class Github {
 
     this.repo = repo;
     this.token = token;
-    this.octokit_options = {};
-
-    if (!repo.includes('github.com')) {
-      const repo_url = new url.URL(repo);
-
-      this.octokit_options.baseUrl = 'https://' + repo_url.host + '/api/v3';
-    }
   }
 
   owner_repo(opts = {}) {
@@ -52,7 +55,7 @@ class Github {
 
     const { url: commit_url } = await octokit(
       this.token,
-      this.octokit_options
+      this.repo
     ).repos.createCommitComment({
       ...owner_repo({ uri: this.repo }),
       body,
@@ -74,7 +77,7 @@ class Github {
     } = opts;
 
     const name = title;
-    return await octokit(this.token, this.octokit_options).checks.create({
+    return await octokit(this.token, this.repo).checks.create({
       ...owner_repo({ uri: this.repo }),
       head_sha,
       started_at,
@@ -92,7 +95,7 @@ class Github {
 
   async runner_token() {
     const { owner, repo } = owner_repo({ uri: this.repo });
-    const { actions } = octokit(this.token, this.octokit_options);
+    const { actions } = octokit(this.token, this.repo);
 
     if (typeof repo !== 'undefined') {
       const {

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -36,9 +36,9 @@ class Github {
     this.octokit_options = {};
 
     if (!repo.includes('github.com')) {
-      const repo_url = url.parse(repo);
+      const repo_url = new url.URL(repo);
 
-      this.octokit_options['baseUrl'] = 'https://' + repo_url.host + '/api/v3';
+      this.octokit_options.baseUrl = 'https://' + repo_url.host + '/api/v3';
     }
   }
 


### PR DESCRIPTION
Hi there,

We'd like to use CML with our GitHub Enterprise Server. I had to modify cml to be able to override the optional `Octokit` `baseUrl` parameter. With this change cml users can use the `GITHUB_BASE_URL` env. var to set the `baseUrl` to use.

```
GITHUB_BASE_URL="https://<Github Enterpriser Server Host>/api/v3"
```