### PR TITLE
Watermark uri entities

### DIFF
--- a/bin/cml-publish.js
+++ b/bin/cml-publish.js
@@ -10,14 +10,25 @@ const yargs = require('yargs');
 const CML = require('../src/cml');
 
 const run = async (opts) => {
-  const { data, file, 'gitlab-uploads': gitlab_uploads } = opts;
+  const {
+    data,
+    file,
+    'gitlab-uploads': gitlab_uploads,
+    'rm-watermark': rm_watermark
+  } = opts;
 
   const path = opts._[0];
   let buffer;
   if (data) buffer = Buffer.from(data, 'binary');
 
   const cml = new CML(opts);
-  const output = await cml.publish({ buffer, path, gitlab_uploads, ...opts });
+  const output = await cml.publish({
+    ...opts,
+    buffer,
+    path,
+    gitlab_uploads,
+    rm_watermark
+  });
 
   if (!file) print(output);
   else await fs.writeFile(file, output);
@@ -44,6 +55,8 @@ const argv = yargs
     'native',
     "Uses driver's native capabilities to upload assets instead of CML's storage."
   )
+  .boolean('rm-watermark')
+  .describe('rm-watermark', 'Avoid CML watermark.')
   .default('file')
   .describe(
     'file',

--- a/bin/cml-publish.test.js
+++ b/bin/cml-publish.test.js
@@ -20,6 +20,7 @@ describe('CML e2e', () => {
                                           [deprecated: Use --native instead] [boolean]
         --native          Uses driver's native capabilities to upload assets instead
                           of CML's storage.                                  [boolean]
+        --rm-watermark    Avoid CML watermark.                               [boolean]
         --file, -f        Append the output to the given file. Create it if does not
                           exist.
         --repo            Specifies the repo to be used. If not specified is extracted

--- a/bin/cml-send-comment.js
+++ b/bin/cml-send-comment.js
@@ -36,7 +36,7 @@ const argv = yargs
   .deprecateOption('head-sha', 'Use commit-sha instead')
   .boolean('rm-watermark')
   .describe(
-    'no-watermark',
+    'rm-watermark',
     'Avoid watermark. CML needs a watermark to be able to distinguish CML reports from other comments in order to provide extra functionality.'
   )
   .default('repo')

--- a/bin/cml-send-comment.test.js
+++ b/bin/cml-send-comment.test.js
@@ -23,9 +23,9 @@ describe('Comment integration tests', () => {
         --commit-sha    Commit SHA linked to this comment. Defaults to HEAD.
         --head-sha      Commit SHA linked to this comment. Defaults to HEAD.
                                                   [deprecated: Use commit-sha instead]
-        --no-watermark  Avoid watermark. CML needs a watermark to be able to
+        --rm-watermark  Avoid watermark. CML needs a watermark to be able to
                         distinguish CML reports from other comments in order to
-                        provide extra functionality.
+                        provide extra functionality.                         [boolean]
         --repo          Specifies the repo to be used. If not specified is extracted
                         from the CI ENV.
         --token         Personal access token to be used. If not specified in

--- a/bin/cml-tensorboard-dev.js
+++ b/bin/cml-tensorboard-dev.js
@@ -29,7 +29,8 @@ const run = async (opts) => {
     logdir,
     name,
     description,
-    title
+    title,
+    'rm-watermark': rm_watermark
   } = opts;
 
   // set credentials
@@ -70,7 +71,7 @@ const run = async (opts) => {
     if (matches.length) {
       let output = matches[0];
 
-      output = watermark_uri({ uri: output, type: 'tb' });
+      if (!rm_watermark) output = watermark_uri({ uri: output, type: 'tb' });
 
       if (md) output = `[${title || name}](${output})`;
 
@@ -121,6 +122,7 @@ const argv = yargs
     'file',
     'Append the output to the given file. Create it if does not exist.'
   )
+  .describe('rm-watermark', 'Avoid CML watermark.')
   .alias('file', 'f')
   .help('h').argv;
 

--- a/bin/cml-tensorboard-dev.js
+++ b/bin/cml-tensorboard-dev.js
@@ -9,7 +9,7 @@ const { spawn } = require('child_process');
 const { homedir } = require('os');
 const tempy = require('tempy');
 
-const { exec } = require('../src/utils');
+const { exec, watermark_uri } = require('../src/utils');
 
 const { TB_CREDENTIALS } = process.env;
 
@@ -69,6 +69,8 @@ const run = async (opts) => {
 
     if (matches.length) {
       let output = matches[0];
+
+      output = watermark_uri({ uri: output, type: 'tb' });
 
       if (md) output = `[${title || name}](${output})`;
 

--- a/bin/cml-tensorboard-dev.test.js
+++ b/bin/cml-tensorboard-dev.test.js
@@ -57,5 +57,6 @@ describe('CML e2e', () => {
 
     expect(is_running).toBe(true);
     expect(output.startsWith(`[${title}](https://`)).toBe(true);
+    expect(output.includes('cml=tb')).toBe(true);
   });
 });

--- a/bin/cml-tensorboard-dev.test.js
+++ b/bin/cml-tensorboard-dev.test.js
@@ -37,6 +37,7 @@ describe('CML e2e', () => {
         --title, -t        Markdown title, if not specified, param name will be used.
         --file, -f         Append the output to the given file. Create it if does not
                            exist.
+        --rm-watermark     Avoid CML watermark.
         -h                 Show help                                         [boolean]
         --plugins"
     `);

--- a/src/cml.js
+++ b/src/cml.js
@@ -80,7 +80,7 @@ class CML {
   }
 
   async publish(opts = {}) {
-    const { title = '', md, native, gitlab_uploads } = opts;
+    const { title = '', md, native, gitlab_uploads, rm_watermark } = opts;
 
     let mime, uri;
     if (native || gitlab_uploads) {
@@ -90,8 +90,10 @@ class CML {
       ({ mime, uri } = await upload(opts));
     }
 
-    const [, type] = mime.split('/');
-    uri = watermark_uri({ uri, type });
+    if (!rm_watermark) {
+      const [, type] = mime.split('/');
+      uri = watermark_uri({ uri, type });
+    }
 
     if (md && mime.match('(image|video)/.*'))
       return `![](${uri}${title ? ` "${title}"` : ''})`;

--- a/src/cml.js
+++ b/src/cml.js
@@ -4,7 +4,7 @@ const strip_auth = require('strip-url-auth');
 
 const Gitlab = require('./drivers/gitlab');
 const Github = require('./drivers/github');
-const { upload, exec } = require('./utils');
+const { upload, exec, watermark_uri } = require('./utils');
 
 const uri_no_trailing_slash = (uri) => {
   return uri.endsWith('/') ? uri.substr(0, uri.length - 1) : uri;
@@ -89,6 +89,9 @@ class CML {
     } else {
       ({ mime, uri } = await upload(opts));
     }
+
+    const [, type] = mime.split('/');
+    uri = watermark_uri({ uri, type });
 
     if (md && mime.match('(image|video)/.*'))
       return `![](${uri}${title ? ` "${title}"` : ''})`;

--- a/src/cml.test.js
+++ b/src/cml.test.js
@@ -31,6 +31,7 @@ describe('Github tests', () => {
     const output = await new CML().publish({ path });
 
     expect(output.startsWith('https://')).toBe(true);
+    expect(output.includes('cml=png')).toBe(true);
   });
 
   test('Publish image with markdown', async () => {
@@ -41,6 +42,7 @@ describe('Github tests', () => {
 
     expect(output.startsWith('![](https://')).toBe(true);
     expect(output.endsWith(` "${title}")`)).toBe(true);
+    expect(output.includes('cml=png')).toBe(true);
   });
 
   test('Publish a non image file in markdown', async () => {
@@ -51,6 +53,8 @@ describe('Github tests', () => {
 
     expect(output.startsWith(`[${title}](https://`)).toBe(true);
     expect(output.endsWith(')')).toBe(true);
+    console.log(output);
+    expect(output.includes('cml=pdf')).toBe(true);
   });
 
   test('Comment should succeed with a valid sha', async () => {
@@ -108,6 +112,7 @@ describe('Gitlab tests', () => {
     });
 
     expect(output.startsWith('https://')).toBe(true);
+    expect(output.includes('cml=png')).toBe(true);
   });
 
   test('Publish image using gl with markdown', async () => {
@@ -123,6 +128,7 @@ describe('Gitlab tests', () => {
 
     expect(output.startsWith('![](https://')).toBe(true);
     expect(output.endsWith(` "${title}")`)).toBe(true);
+    expect(output.includes('cml=png')).toBe(true);
   });
 
   test('Publish a non image file using gl in markdown', async () => {
@@ -138,6 +144,7 @@ describe('Gitlab tests', () => {
 
     expect(output.startsWith(`[${title}](https://`)).toBe(true);
     expect(output.endsWith(')')).toBe(true);
+    expect(output.includes('cml=pdf')).toBe(true);
   });
 
   test('Publish a non image file using native', async () => {
@@ -153,6 +160,7 @@ describe('Gitlab tests', () => {
 
     expect(output.startsWith(`[${title}](https://`)).toBe(true);
     expect(output.endsWith(')')).toBe(true);
+    expect(output.includes('cml=pdf')).toBe(true);
   });
 
   test('Publish should fail with an invalid driver', async () => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -135,6 +135,14 @@ const parse_param_newline = (param) => {
   return param.replace(/\\n/g, '\n');
 };
 
+const watermark_uri = (opts = {}) => {
+  const { uri, type } = opts;
+  const url = new URL(uri);
+  url.searchParams.append('cml', type);
+
+  return url.toString();
+};
+
 exports.exec = exec;
 exports.fetch_upload_data = fetch_upload_data;
 exports.upload = upload;
@@ -143,3 +151,4 @@ exports.sleep = sleep;
 exports.is_proc_running = is_proc_running;
 exports.ssh_public_from_private_rsa = ssh_public_from_private_rsa;
 exports.parse_param_newline = parse_param_newline;
+exports.watermark_uri = watermark_uri;


### PR DESCRIPTION
Viewer needs to extract the CML entities like TB. 
This PR extends the urls watermarking them with an inoffensive  url parameter ```cml={type}```. 
Every url generated by ```cml-publish``` or ```cml-tensorboard-dev``` will have this parameter:
 - works in md or plain url
 - type helps the viewer to understand the type so in publish is the mime and in tensorboard is ```tb```

Examples
 - ```[my title](https://asset.cml.dev/78cf3f9cc141fc6078afef42146401ca53ede7d2?cml=pdf)```
 - ```https://tensorboard.dev/experiment/y43T4sOlRwONkIeh6j6uLQ?cml=tb```

closes #319 