### PR TITLE
Release v0.2.6 Name sync, regions and types (#273,#320,#282,#305,#306,#322)

### DIFF
--- a/bin/cml-cloud-runner.js
+++ b/bin/cml-cloud-runner.js
@@ -243,7 +243,7 @@ const argv = yargs
   .default('region')
   .describe(
     'region',
-    'Region where the instance is deployed. Defaults to us-east-1.'
+    'Region where the instance is deployed. Defaults to us-west.'
   )
   .describe('type', 'Instance type. Defaults to m.')
   .default('hdd-size')

--- a/bin/cml-cloud-runner.js
+++ b/bin/cml-cloud-runner.js
@@ -245,9 +245,9 @@ const argv = yargs
     'region',
     'Region where the instance is deployed. Defaults to us-east-1.'
   )
-  .describe('type', 'Instance type. Defaults to t2.micro.')
+  .describe('type', 'Instance type. Defaults to m.')
   .default('hdd-size')
-  .describe('hdd-size', 'HDD size in GB. Defaults to 100. Minimum is 100.')
+  .describe('hdd-size', 'HDD size in GB. Defaults to 10.')
   .default('tf-file')
   .describe(
     'tf-file',

--- a/bin/cml-cloud-runner.test.js
+++ b/bin/cml-cloud-runner.test.js
@@ -16,10 +16,9 @@ describe('CML e2e', () => {
                            before shutting down. Defaults to 5 min
         --image            Docker image. Defaults to dvcorg/cml:latest
         --name             Name displayed in the repo once registered.
-        --region           Region where the instance is deployed. Defaults to
-                           us-east-1.
-        --type             Instance type. Defaults to t2.micro.
-        --hdd-size         HDD size in GB. Defaults to 100. Minimum is 100.
+        --region           Region where the instance is deployed. Defaults to us-west.
+        --type             Instance type. Defaults to m.
+        --hdd-size         HDD size in GB. Defaults to 10.
         --tf-file          Use a tf file configuration ignoring region, type and
                            hdd_size.
         --rsa-private-key  Your private RSA SHH key. If not provided will be generated

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvcorg/cml",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvcorg/cml",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "author": {
     "name": "DVC",
     "url": "http://cml.dev"


### PR DESCRIPTION
This PR introduces:
 - Name of runner and machine is now synced. AWS private key is also synced with the same name.
 - Add the first iteration of regions and machine type definition
 - Fixes some issues regarding deploying machines like time to dispose and spinning several machines instead of one.

closes #273
closes #320
closes #282
closes #305 
closes #306
closes #322