### PR TITLE
Attached run does not wait runner

### DIFF
--- a/bin/cml-cloud-runner.js
+++ b/bin/cml-cloud-runner.js
@@ -127,7 +127,8 @@ const setup_runners = async (opts) => {
       );
 
     await ssh.dispose();
-    await cml.await_runner({ name: instance_name });
+
+    if (!attached) await cml.await_runner({ name: instance_name });
   }
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvcorg/cml",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvcorg/cml",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "author": {
     "name": "DVC",
     "url": "http://cml.dev"


### PR DESCRIPTION
If ```attached``` there is an error having to wait the runner since it. has been disposed before the wait occurs.