### PR TITLE
Fix terraform tfstate to an specific version

### DIFF
--- a/bin/cml-cloud-runner.js
+++ b/bin/cml-cloud-runner.js
@@ -19,6 +19,7 @@ let cml;
 
 const TF_FOLDER = '.cml';
 const TF_NO_LOCAL = '.nolocal';
+const TF_VERSION = '0.13.2';
 
 const ssh_connect = async (opts) => {
   const { host, username, private_key: privateKey, max_tries = 5 } = opts;
@@ -193,11 +194,12 @@ resource "iterative_machine" "machine" {
   console.log(await exec(`terraform init ${TF_FOLDER}`));
   console.log(await exec(`terraform apply -auto-approve ${TF_FOLDER}`));
 
-  const terraform_state_json = await fs.readFile(
-    path.join(TF_FOLDER, 'terraform.tfstate'),
-    'utf-8'
-  );
+  const terraform_state_json = await fs.readFile(tfstate_path, 'utf-8');
+
   const terraform_state = JSON.parse(terraform_state_json);
+  terraform_state.terraform_version = TF_VERSION;
+
+  await fs.writeFile(tfstate_path, JSON.stringify(terraform_state, null, '\t'));
 
   return terraform_state;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvcorg/cml",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvcorg/cml",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "author": {
     "name": "DVC",
     "url": "http://cml.dev"


### PR DESCRIPTION
TF can handle a tfstate generated with a previous version of TF however its not the case for newer TF versions.
I have considered and tested many versions like restrict the version or install the specific version in cml deferred (first approach) however thats slow and a spot instance could be released before TF even finishes the install.

closes #344 