### PR TITLE
Add readiness checks

### DIFF
--- a/bin/cml-runner.js
+++ b/bin/cml-runner.js
@@ -194,13 +194,22 @@ const run_local = async (opts) => {
 
   const data_handler = (data) => {
     const log = cml.parse_runner_log({ data });
-    log && console.log(JSON.stringify(log));
 
-    if (log && log.status === 'job_started') {
-      RUNNER_JOBS_RUNNING.push(1);
-      RUNNER_TIMEOUT_TIMER = 0;
-    } else if (log && log.status === 'job_ended') {
-      RUNNER_JOBS_RUNNING.pop();
+    if (log) {
+      console.log(JSON.stringify(log));
+
+      switch (log.status) {
+        case 'job_started':
+          RUNNER_JOBS_RUNNING.push(1);
+          RUNNER_TIMEOUT_TIMER = 0;
+          break;
+        case 'job_ended':
+          RUNNER_JOBS_RUNNING.pop();
+          break;
+        case 'ready':
+          fs.open('/tmp/ready.flag', 'w');
+          break;
+      }
     }
   };
   proc.stderr.on('data', data_handler);


### PR DESCRIPTION
Every driver with self-hosted runner support will create the `/tmp/ready.flag` file once the process is ready to accept new jobs, allowing Kubernetes to detect the ready condition without resorting to arbitrary delays nor trusting the connection to be _quick enough_.