### PR TITLE
Single job mode

### DIFF
--- a/bin/cml-runner.js
+++ b/bin/cml-runner.js
@@ -20,6 +20,7 @@ const {
   RUNNER_IDLE_TIMEOUT = 5 * 60,
   RUNNER_LABELS = 'cml',
   RUNNER_NAME = NAME,
+  RUNNER_SINGLE = false,
   RUNNER_DRIVER,
   RUNNER_REPO,
   repo_token
@@ -183,12 +184,13 @@ const run_cloud = async (opts) => {
 
 const run_local = async (opts) => {
   console.log(`Launching ${cml.driver} runner`);
-  const { workdir, name, labels, idle_timeout } = opts;
+  const { workdir, name, labels, single, idle_timeout } = opts;
 
   const proc = await cml.start_runner({
     workdir,
     name,
     labels,
+    single,
     idle_timeout
   });
 
@@ -229,7 +231,7 @@ const run = async (opts) => {
   process.on('SIGQUIT', () => shutdown(opts));
 
   opts.workdir = RUNNER_PATH;
-  const { driver, repo, token, cloud, workdir, name, tf_resource } = opts;
+  const { driver, repo, token, single, cloud, workdir, name, tf_resource } = opts;
 
   cml = new CML({ driver, repo, token });
 
@@ -281,6 +283,10 @@ const opts = decamelize(
     )
     .default('name', RUNNER_NAME)
     .describe('name', 'Name displayed in the repo once registered')
+
+    .boolean('single')
+    .default('single', RUNNER_SINGLE)
+    .describe('single', 'If specified, exit after running a single job.')
 
     .default('driver', RUNNER_DRIVER)
     .describe('driver', 'If not specify it infers it from the ENV.')

--- a/bin/cml-runner.js
+++ b/bin/cml-runner.js
@@ -231,7 +231,16 @@ const run = async (opts) => {
   process.on('SIGQUIT', () => shutdown(opts));
 
   opts.workdir = RUNNER_PATH;
-  const { driver, repo, token, single, cloud, workdir, name, tf_resource } = opts;
+  const {
+    driver,
+    repo,
+    token,
+    single,
+    cloud,
+    workdir,
+    name,
+    tf_resource
+  } = opts;
 
   cml = new CML({ driver, repo, token });
 

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -178,10 +178,9 @@ class Github {
         )}"`
       );
 
-      return spawn(
-        resolve(workdir, 'run.sh') + (single ? ' --once' : ''),
-        { shell: true }
-      );
+      return spawn(resolve(workdir, 'run.sh') + (single ? ' --once' : ''), {
+        shell: true
+      });
     } catch (err) {
       throw new Error(`Failed preparing GitHub runner: ${err.message}`);
     }

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -149,7 +149,7 @@ class Github {
   }
 
   async start_runner(opts) {
-    const { workdir, name, labels } = opts;
+    const { workdir, single, name, labels } = opts;
 
     try {
       const runner_cfg = resolve(workdir, '.runner');
@@ -178,7 +178,10 @@ class Github {
         )}"`
       );
 
-      return spawn(resolve(workdir, 'run.sh'), { shell: true });
+      return spawn(
+        resolve(workdir, 'run.sh') + (single ? ' --once' : ''),
+        { shell: true }
+      );
     } catch (err) {
       throw new Error(`Failed preparing GitHub runner: ${err.message}`);
     }

--- a/src/drivers/gitlab.js
+++ b/src/drivers/gitlab.js
@@ -91,7 +91,7 @@ class Gitlab {
   }
 
   async start_runner(opts) {
-    const { workdir, idle_timeout, labels, name } = opts;
+    const { workdir, idle_timeout, single, labels, name } = opts;
 
     let gpu = true;
     try {
@@ -120,7 +120,8 @@ class Gitlab {
         --wait-timeout ${idle_timeout} \
         --executor "${IN_DOCKER ? 'shell' : 'docker'}" \
         --docker-image "dvcorg/cml:latest" \
-        --docker-runtime "${gpu ? 'nvidia' : ''}"`;
+        --docker-runtime "${gpu ? 'nvidia' : ''}" \
+        ${single ? '--max-builds 1' : ''}`;
 
       return spawn(command, { shell: true });
     } catch (err) {


### PR DESCRIPTION
Setting the RUNNER_SINGLE environment variable or passing the `--single` command-line argument will cause the runner to exit after running a single job. This is specially useful when runners are instantianted in a one-shot fashion, like in the Kubernetes use case, where a new _ad-hoc_ runner is created each time a workflow is run.

The GitHub counterpart doesn't seem to be part of the purposefully public interface and seems to have some issues (https://github.com/actions/runner/issues/510), but it's [being used internally](https://github.com/actions/runner/blob/a9be5f65578a8225c6a024799f572ad2066c4fd8/.github/workflows/e2etest.yml#L173) on the official repository tests. While I think that it would be interesting to offer this functionality to the user, it looks like we'll have to wait for this kind of feature to be fully implemented on the official runner. 

_Note: please use [squash and merge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-merges#squash-and-merge-your-pull-request-commits) whe merging this pull request to avoid adding a separate commit for the `prettier` modifications._