### PR TITLE
Add missing await to docker-machine shutdown code

### DIFF
--- a/bin/cml-runner.js
+++ b/bin/cml-runner.js
@@ -95,7 +95,7 @@ const shutdown = async (opts) => {
     await destroy_terraform();
   } else {
     RUNNER_LAUNCHED && (await unregister_runner());
-    DOCKER_MACHINE && shutdown_docker_machine();
+    DOCKER_MACHINE && (await shutdown_docker_machine());
     await shutdown_tf();
   }
 


### PR DESCRIPTION
@btjones-me [discovered](https://discord.com/channels/485586884165107732/728693131557732403/810990082051538966) that [AWS] machines weren't being terminated by `docker-machine` during the shutdown process, and it turned to be due to a missing `await`.