### PR TITLE
Fix setup python

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -96,9 +96,9 @@ RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add - && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
     
 # FIX setup-python Action
-RUN mkdir /__t
-RUN ln -s /__t /opt/hostedtoolcache
-ENV AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache
+# RUN mkdir /__t
+# RUN ln -s /__t /opt/hostedtoolcache
+# ENV AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache
 
 # GITLAB RUNNER AND GITHUB RUNNER
 ENV RUNNER_PATH=/home/runner

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -95,11 +95,6 @@ RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add - && \
     apt update && apt-get install -y terraform && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
     
-# FIX setup-python Action
-# RUN mkdir /__t
-# RUN ln -s /__t /opt/hostedtoolcache
-# ENV AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache
-
 # GITLAB RUNNER AND GITHUB RUNNER
 ENV RUNNER_PATH=/home/runner
 ENV RUNNER_ALLOW_RUNASROOT=1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvcorg/cml",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvcorg/cml",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "author": {
     "name": "DVC",
     "url": "http://cml.dev"


### PR DESCRIPTION
Fixes setup-python.
Originally we did a trick to fix it... apparently #181 however the workflow seems to not be working properly using CML ami.
However this fix is tricky because might be breaking local self hosted runners deployed with docker. 
The key thing to consider is that GH is not supporting non Ubuntu distros and a small subset of MacOS

closes #386 