### PR TITLE
Update Dockerfile to support Go >= 1.16

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -81,7 +81,8 @@ RUN apt-get update && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 # TENSORFLOW ENDS
 
-# DOCKER, OUR CUSTOM DOCKER MACHINE FORK THAT SUPPORTS GPU ACCELARATOR (DEPRECATED)
+# DOCKER, OUR CUSTOM DOCKER MACHINE FORK THAT SUPPORTS GPU ACCELERATOR (DEPRECATED)
+ENV GO111MODULE=auto
 RUN curl -fsSL https://get.docker.com -o get-docker.sh && sh get-docker.sh && \
     go get github.com/iterative/machine && \
     mv $(go env GOPATH)/src/github.com/iterative $(go env GOPATH)/src/github.com/docker && \

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvcorg/cml",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvcorg/cml",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "author": {
     "name": "DVC",
     "url": "http://cml.dev"


### PR DESCRIPTION
The container specification is [instaling](https://github.com/iterative/cml/blob/73e2c96adab1e27b6528bdf9ae2b38dbd9ac4474/docker/Dockerfile#L33) Go from the [`longsleep/golang-backports`](https://launchpad.net/~longsleep/+archive/ubuntu/golang-backports) unofficial [PPA](https://en.wikipedia.org/wiki/Ubuntu#Package_Archives), and [we are not pinning](https://github.com/iterative/cml/blob/73e2c96adab1e27b6528bdf9ae2b38dbd9ac4474/docker/Dockerfile#L39) the install to a specific Go version, so it will use the latest version it finds. [As per the failed workflow logs](https://github.com/iterative/cml/runs/1963411862?check_suite_focus=true#step:3:1044), the latest version is Go 1.16, which [was published yesterday](https://launchpad.net/~longsleep/+archive/ubuntu/golang-backports/+sourcepub/12160015/+listing-archive-extra) on the repository we're using.

Go 1.16 introduces some really important changes; among them, [using modules by default](https://blog.golang.org/go116-module-changes). Apart from the expected benefits, this also implies that `go get` won't use `~/go/src` anymore and the packages will be saved to `~/go/pkg` instead, effectively breaking the container builds.

This pull request forces Go to follow the same behavior as in earlier versions by setting the [`GO111MODULE`](https://golang.org/ref/mod#mod-commands) environment variable to [`auto`](https://golang.org/ref/mod#mod-commands) so packages get downloaded to the legacy path.

Fixes #414 