### PR TITLE
Add support for singleton runners

### DIFF
--- a/bin/cml-runner.js
+++ b/bin/cml-runner.js
@@ -268,11 +268,6 @@ const run = async (opts) => {
   }
 
   // if (name !== NAME) {
-  //   console.log(
-  //     'The --name option is deprecated: please use --labels to differentiate runners instead.'
-  //   );
-  // }
-
   await cml.repo_token_check();
 
   if (await cml.runner_by_name({ name })) {

--- a/bin/cml-runner.js
+++ b/bin/cml-runner.js
@@ -267,6 +267,12 @@ const run = async (opts) => {
     await tf.save_tfstate({ tfstate, path });
   }
 
+  if (name !== NAME) {
+    console.log(
+      'The --name option is deprecated: please use --labels to differentiate runners instead.'
+    );
+  }
+
   await cml.repo_token_check();
   if (await cml.runner_by_name({ name })) {
     throw new Error(

--- a/src/cml.js
+++ b/src/cml.js
@@ -197,6 +197,10 @@ class CML {
     return await get_driver(this).runner_by_name(opts);
   }
 
+  async runners_by_labels(opts = {}) {
+    return await get_driver(this).runners_by_labels(opts);
+  }
+
   async await_runner(opts = {}) {
     const { name, max_tries = 100 } = opts;
 

--- a/src/drivers/bitbucket_cloud.js
+++ b/src/drivers/bitbucket_cloud.js
@@ -76,6 +76,10 @@ class BitBucketCloud {
     throw new Error('BitBucket Cloud does not support runner_by_name!');
   }
 
+  async runners_by_labels(opts = {}) {
+    throw new Error('BitBucket Cloud does not support runner_by_labels!');
+  }
+
   async request(opts = {}) {
     const { token, api } = this;
     const { endpoint, method = 'GET', body } = opts;

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -213,14 +213,14 @@ class Github {
 
   async runner_by_name(opts = {}) {
     const { name } = opts;
-    const runners = this.get_runners(opts);
+    const runners = await this.get_runners(opts);
     const runner = runners.filter((runner) => runner.name === name)[0];
     if (runner) return { id: runner.id, name: runner.name };
   }
 
   async runners_by_labels(opts = {}) {
     const { labels } = opts;
-    const runners = this.get_runners(opts);
+    const runners = await this.get_runners(opts);
     return runners
       .filter((runner) =>
         labels

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -186,8 +186,7 @@ class Github {
     }
   }
 
-  async runner_by_name(opts = {}) {
-    const { name } = opts;
+  async get_runners(opts = {}) {
     const { owner, repo } = owner_repo({ uri: this.repo });
     const { actions } = octokit(this.token, this.repo);
     let runners = [];
@@ -209,8 +208,28 @@ class Github {
       }));
     }
 
+    return runners;
+  }
+
+  async runner_by_name(opts = {}) {
+    const { name } = opts;
+    const runners = this.get_runners(opts);
     const runner = runners.filter((runner) => runner.name === name)[0];
     if (runner) return { id: runner.id, name: runner.name };
+  }
+
+  async runners_by_labels(opts = {}) {
+    const { labels } = opts;
+    const runners = this.get_runners(opts);
+    return runners
+      .filter((runner) =>
+        labels
+          .split(',')
+          .every((label) =>
+            runner.labels.map(({ name }) => name).includes(label)
+          )
+      )
+      .map((runner) => ({ id: runner.id, name: runner.name }));
   }
 }
 

--- a/src/drivers/gitlab.js
+++ b/src/drivers/gitlab.js
@@ -141,6 +141,13 @@ class Gitlab {
     if (runner) return { id: runner.id, name: runner.name };
   }
 
+  async runners_by_labels(opts = {}) {
+    const { labels } = opts;
+    const endpoint = `/runners?per_page=100?tag_list=${labels}`;
+    const runners = await this.request({ endpoint, method: 'GET' });
+    return runners.map((runner) => ({ id: runner.id, name: runner.name }));
+  }
+
   async request(opts = {}) {
     const { token, api_v4 } = this;
     const { endpoint, method = 'GET', body, raw } = opts;


### PR DESCRIPTION
The --reuse-existing flag will cause cml-runner to look for already existing runners with the specified --labels and skip creating a new one if that's the case.