### PR TITLE
Increase checkbot runner timeouts

### DIFF
--- a/.github/workflows/checkbot.yml
+++ b/.github/workflows/checkbot.yml
@@ -71,7 +71,7 @@ jobs:
             --cloud azure \
             --cloud-region eastus \
             --cloud-type Standard_NC6 \
-            --idle-timeout 1800 \
+            --idle-timeout 3600 \
             --labels cml-runner-az-gpu
 
           cml-runner \
@@ -79,7 +79,7 @@ jobs:
             --cloud aws \
             --cloud-region us-west \
             --cloud-type g2.2xlarge \
-            --idle-timeout 1800 \
+            --idle-timeout 3600 \
             --labels cml-runner-aws-gpu
 
   test_machine_aws:


### PR DESCRIPTION
Increase checkbot runner timeouts from 30 minutes to 60 minutes in order to diagnose an Azure issue.