### PR TITLE
Update dependacron pull request step

### DIFF
--- a/.github/workflows/dependancron.yml
+++ b/.github/workflows/dependancron.yml
@@ -34,7 +34,7 @@ jobs:
 
     - name: Create Pull Request
       if: steps.check.outputs.update == 'true'
-      uses: peter-evans/create-pull-request@v2
+      uses: peter-evans/create-pull-request@v3
       with:
         title: 'chore: dependancron update dependencies'
         body: ${{ steps.check.outputs.comment }}


### PR DESCRIPTION
This pull request updates the major version for the [`peter-evans/create-pull-request`](https://github.com/peter-evans/create-pull-request) GitHub Action step of the `dependacron` workflow.

Required in order to avoid a fatal error caused by the  hard deprecation of the `set-env` and `add-path` standard output commands after CVE-2020-15228.

```console
Error: Unable to process command '::set-env name=pythonLocation::/opt/hostedtoolcache/Python/3.9.2/x64' successfully.
Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
Error: Unable to process command '::add-path::/opt/hostedtoolcache/Python/3.9.2/x64' successfully.
Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
Error: Unable to process command '::add-path::/opt/hostedtoolcache/Python/3.9.2/x64/bin' successfully.
Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```