### PR TITLE
Add sanity check for cml-publish with filesystem paths

### DIFF
--- a/bin/cml-publish.test.js
+++ b/bin/cml-publish.test.js
@@ -105,4 +105,18 @@ describe('CML e2e', () => {
 
     expect(output.startsWith('https://')).toBe(true);
   });
+
+  test('cml-publish /nonexistent produces file error', async () => {
+    await expect(
+      exec(`echo none | node ./bin/cml-publish.js /nonexistent`)
+    ).rejects.toThrowError(
+      'Path /nonexistent does not exist or is not a readable file'
+    );
+  });
+
+  test('echo invalid | cml-publish produces buffer mime type error', async () => {
+    await expect(
+      exec(`echo invalid | node ./bin/cml-publish.js`)
+    ).rejects.toThrowError('Failed guessing mime type of buffer');
+  });
 });

--- a/bin/cml-publish.test.js
+++ b/bin/cml-publish.test.js
@@ -108,10 +108,8 @@ describe('CML e2e', () => {
 
   test('cml-publish /nonexistent produces file error', async () => {
     await expect(
-      exec(`echo none | node ./bin/cml-publish.js /nonexistent`)
-    ).rejects.toThrowError(
-      'Path /nonexistent does not exist or is not a readable file'
-    );
+      exec('echo none | node ./bin/cml-publish.js /nonexistent')
+    ).rejects.toThrowError('ENOENT: no such file or directory, stat');
   });
 
   test('echo invalid | cml-publish produces buffer mime type error', async () => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -54,7 +54,15 @@ const mime_type = async (opts) => {
 
 const fetch_upload_data = async (opts) => {
   const { path, buffer } = opts;
-
+  
+  if (path) {
+    try {
+      await fs.promises.access(path, fs.constants.F_OK | fs.constants.R_OK);
+    } catch (err) {
+      throw new Error(`Path ${path} does not exist or is not a readable file.`);
+    }
+  }
+  
   const mime = await mime_type(opts);
   const data = path ? fs.createReadStream(path) : buffer;
   const size = path ? (await fs.promises.stat(path)).size : buffer.length;

--- a/src/utils.js
+++ b/src/utils.js
@@ -54,7 +54,7 @@ const mime_type = async (opts) => {
 
 const fetch_upload_data = async (opts) => {
   const { path, buffer } = opts;
-  
+
   if (path) {
     try {
       await fs.promises.access(path, fs.constants.F_OK | fs.constants.R_OK);
@@ -62,7 +62,7 @@ const fetch_upload_data = async (opts) => {
       throw new Error(`Path ${path} does not exist or is not a readable file.`);
     }
   }
-  
+
   const mime = await mime_type(opts);
   const data = path ? fs.createReadStream(path) : buffer;
   const size = path ? (await fs.promises.stat(path)).size : buffer.length;

--- a/src/utils.js
+++ b/src/utils.js
@@ -55,17 +55,9 @@ const mime_type = async (opts) => {
 const fetch_upload_data = async (opts) => {
   const { path, buffer } = opts;
 
-  if (path) {
-    try {
-      await fs.promises.access(path, fs.constants.F_OK | fs.constants.R_OK);
-    } catch (err) {
-      throw new Error(`Path ${path} does not exist or is not a readable file`);
-    }
-  }
-
-  const mime = await mime_type(opts);
-  const data = path ? fs.createReadStream(path) : buffer;
   const size = path ? (await fs.promises.stat(path)).size : buffer.length;
+  const data = path ? fs.createReadStream(path) : buffer;
+  const mime = await mime_type(opts);
 
   return { mime, size, data };
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -59,7 +59,7 @@ const fetch_upload_data = async (opts) => {
     try {
       await fs.promises.access(path, fs.constants.F_OK | fs.constants.R_OK);
     } catch (err) {
-      throw new Error(`Path ${path} does not exist or is not a readable file.`);
+      throw new Error(`Path ${path} does not exist or is not a readable file`);
     }
   }
 


### PR DESCRIPTION
Resolves #308 and probably also closes #401 by throwing a meaningful error for paths that don't exist, aren't files or can't be read.