### PR TITLE
Destroy runner log

### DIFF
--- a/bin/cml-runner.js
+++ b/bin/cml-runner.js
@@ -43,6 +43,7 @@ const shutdown = async (opts) => {
   const { name, workdir = '' } = opts;
   const tf_path = workdir;
 
+  console.log('Destroying runner...');
   if (error) console.error(error);
 
   const unregister_runner = async () => {

--- a/bin/cml-runner.js
+++ b/bin/cml-runner.js
@@ -43,7 +43,9 @@ const shutdown = async (opts) => {
   const { name, workdir = '' } = opts;
   const tf_path = workdir;
 
-  console.log('Destroying runner...');
+  console.log(
+    JSON.stringify({ level: error ? 'error' : 'info', status: 'terminated' })
+  );
   if (error) console.error(error);
 
   const unregister_runner = async () => {


### PR DESCRIPTION
Introduces a constant destroy output. This is needed by the [provider](https://github.com/iterative/terraform-provider-iterative) to be able to wait for the runner to be ready.


