### PR TITLE
Hotfix/unregister before wait v0.3.3

### DIFF
--- a/bin/cml-runner.js
+++ b/bin/cml-runner.js
@@ -97,15 +97,16 @@ const shutdown = async (opts) => {
     }
   };
 
-  console.log(
-    `\tDestroy scheduled: ${RUNNER_DESTROY_DELAY} seconds remaining.`
-  );
-  await sleep(RUNNER_DESTROY_DELAY);
-
   if (cloud) {
     await destroy_terraform();
   } else {
     RUNNER_LAUNCHED && (await unregister_runner());
+
+    console.log(
+      `\tDestroy scheduled: ${RUNNER_DESTROY_DELAY} seconds remaining.`
+    );
+    await sleep(RUNNER_DESTROY_DELAY);
+
     DOCKER_MACHINE && (await shutdown_docker_machine());
     await shutdown_tf();
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvcorg/cml",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvcorg/cml",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "author": {
     "name": "DVC",
     "url": "http://cml.dev"


### PR DESCRIPTION
Fixes the issue that the runner is not unregistered due to the 30 secs delay and inconsistency with the provider graceful shutdown 