### PR TITLE
Automatically detect GitLab API base address

### DIFF
--- a/src/drivers/gitlab.js
+++ b/src/drivers/gitlab.js
@@ -178,9 +178,8 @@ class Gitlab {
     if (endpoint) {
       this.api_v4 = this.api_v4 || (await this.detect_api_v4());
       url = `${this.api_v4}${endpoint}`;
-    } else if (!url) {
-      throw new Error('Gitlab API endpoint not found');
     }
+    if (!url) throw new Error('Gitlab API endpoint not found');
 
     const headers = { 'PRIVATE-TOKEN': token, Accept: 'application/json' };
     const response = await fetch(url, { method, headers, body });


### PR DESCRIPTION
This pull request should fix #463, where a GitLab instance served from a path different from the server root wouldn't be interpreted correctly. It feels [a bit complicated](https://wiki.c2.com/?BigBallOfMud) for my taste, but should perform as expected. 