### PR TITLE
Fix wrong type for Array.find

### DIFF
--- a/src/drivers/gitlab.js
+++ b/src/drivers/gitlab.js
@@ -48,7 +48,7 @@ class Gitlab {
 
     this._detected_base = possible_bases.find(Boolean);
     if (!this._detected_base) throw new Error('GitLab API not found');
-    
+
     return this._detected_base;
   }
 

--- a/src/drivers/gitlab.js
+++ b/src/drivers/gitlab.js
@@ -42,7 +42,7 @@ class Gitlab {
         })
     );
 
-    const detected_base = possible_bases.find(String);
+    const detected_base = possible_bases.find(Boolean);
     if (detected_base) return detected_base;
 
     throw new Error('GitLab API not found');


### PR DESCRIPTION
This pull request fixes a misconception about the properties of `undefined` when cast to `String` versus `Boolean` on the GitLab API detection code. To be merged against the `master` branch if we don't do another release.