### PR TITLE
uppercase REPO_TOKEN

### DIFF
--- a/bin/cml-publish.js
+++ b/bin/cml-publish.js
@@ -71,7 +71,7 @@ const argv = yargs
   .default('token')
   .describe(
     'token',
-    'Personal access token to be used. If not specified in extracted from ENV REPO_TOKEN or GITLAB_TOKEN.'
+    'Personal access token to be used. If not specified, extracted from ENV REPO_TOKEN, GITLAB_TOKEN, GITHUB_TOKEN, or BITBUCKET_TOKEN.'
   )
   .default('driver')
   .choices('driver', ['github', 'gitlab'])

--- a/bin/cml-publish.js
+++ b/bin/cml-publish.js
@@ -71,7 +71,7 @@ const argv = yargs
   .default('token')
   .describe(
     'token',
-    'Personal access token to be used. If not specified in extracted from ENV repo_token or GITLAB_TOKEN.'
+    'Personal access token to be used. If not specified in extracted from ENV REPO_TOKEN or GITLAB_TOKEN.'
   )
   .default('driver')
   .choices('driver', ['github', 'gitlab'])

--- a/bin/cml-publish.test.js
+++ b/bin/cml-publish.test.js
@@ -26,7 +26,7 @@ describe('CML e2e', () => {
         --repo            Specifies the repo to be used. If not specified is extracted
                           from the CI ENV.
         --token           Personal access token to be used. If not specified in
-                          extracted from ENV repo_token or GITLAB_TOKEN.
+                          extracted from ENV REPO_TOKEN or GITLAB_TOKEN.
         --driver          If not specify it infers it from the ENV.
                                                          [choices: \\"github\\", \\"gitlab\\"]
         -h                Show help                                          [boolean]"

--- a/bin/cml-publish.test.js
+++ b/bin/cml-publish.test.js
@@ -25,8 +25,9 @@ describe('CML e2e', () => {
                           exist.
         --repo            Specifies the repo to be used. If not specified is extracted
                           from the CI ENV.
-        --token           Personal access token to be used. If not specified in
-                          extracted from ENV REPO_TOKEN.
+        --token           Personal access token to be used. If not specified,
+                          extracted from ENV REPO_TOKEN, GITLAB_TOKEN, GITHUB_TOKEN,
+                          or BITBUCKET_TOKEN.
         --driver          If not specify it infers it from the ENV.
                                                          [choices: \\"github\\", \\"gitlab\\"]
         -h                Show help                                          [boolean]"

--- a/bin/cml-publish.test.js
+++ b/bin/cml-publish.test.js
@@ -26,7 +26,7 @@ describe('CML e2e', () => {
         --repo            Specifies the repo to be used. If not specified is extracted
                           from the CI ENV.
         --token           Personal access token to be used. If not specified in
-                          extracted from ENV REPO_TOKEN or GITLAB_TOKEN.
+                          extracted from ENV REPO_TOKEN.
         --driver          If not specify it infers it from the ENV.
                                                          [choices: \\"github\\", \\"gitlab\\"]
         -h                Show help                                          [boolean]"

--- a/bin/cml-runner.js
+++ b/bin/cml-runner.js
@@ -25,7 +25,7 @@ const {
   RUNNER_REUSE = false,
   RUNNER_DRIVER,
   RUNNER_REPO,
-  repo_token
+  REPO_TOKEN
 } = process.env;
 
 let cml;
@@ -350,7 +350,7 @@ const opts = decamelize(
       'repo',
       'Repository to be used for registering the runner. If not specified, it will be inferred from the environment'
     )
-    .default('token', repo_token)
+    .default('token', REPO_TOKEN)
     .describe(
       'token',
       'Personal access token to register a self-hosted runner on the repository. If not specified, it will be inferred from the environment'

--- a/bin/cml-send-comment.js
+++ b/bin/cml-send-comment.js
@@ -47,7 +47,7 @@ const argv = yargs
   .default('token')
   .describe(
     'token',
-    'Personal access token to be used. If not specified in extracted from ENV repo_token.'
+    'Personal access token to be used. If not specified in extracted from ENV REPO_TOKEN.'
   )
   .default('driver')
   .choices('driver', ['github', 'gitlab'])

--- a/bin/cml-send-comment.test.js
+++ b/bin/cml-send-comment.test.js
@@ -29,7 +29,7 @@ describe('Comment integration tests', () => {
         --repo          Specifies the repo to be used. If not specified is extracted
                         from the CI ENV.
         --token         Personal access token to be used. If not specified in
-                        extracted from ENV repo_token.
+                        extracted from ENV REPO_TOKEN.
         --driver        If not specify it infers it from the ENV.
                                                          [choices: \\"github\\", \\"gitlab\\"]
         -h              Show help                                            [boolean]"

--- a/bin/cml-send-github-check.js
+++ b/bin/cml-send-github-check.js
@@ -43,7 +43,7 @@ const argv = yargs
   .default('token')
   .describe(
     'token',
-    'Personal access token to be used. If not specified in extracted from ENV repo_token.'
+    'Personal access token to be used. If not specified in extracted from ENV REPO_TOKEN.'
   )
   .help('h')
   .demand(1).argv;

--- a/bin/cml-send-github-check.test.js
+++ b/bin/cml-send-github-check.test.js
@@ -45,7 +45,7 @@ describe('CML e2e', () => {
         --repo        Specifies the repo to be used. If not specified is extracted
                       from the CI ENV.
         --token       Personal access token to be used. If not specified in extracted
-                      from ENV repo_token.
+                      from ENV REPO_TOKEN.
         -h            Show help                                              [boolean]
         --conclusion[choices: \\"success\\", \\"failure\\", \\"neutral\\", \\"cancelled\\", \\"skipped\\",
                       \\"timed_out\\"] [default: Sets the conclusion status of the check.]"

--- a/src/cml.js
+++ b/src/cml.js
@@ -50,12 +50,15 @@ const get_driver = (opts) => {
 
 const infer_token = () => {
   const {
+    REPO_TOKEN,
     repo_token,
     GITHUB_TOKEN,
     GITLAB_TOKEN,
     BITBUCKET_TOKEN
   } = process.env;
-  return repo_token || GITHUB_TOKEN || GITLAB_TOKEN || BITBUCKET_TOKEN;
+  return (
+    REPO_TOKEN || repo_token || GITHUB_TOKEN || GITLAB_TOKEN || BITBUCKET_TOKEN
+  );
 };
 
 class CML {
@@ -231,7 +234,7 @@ class CML {
       await this.runner_token();
     } catch (err) {
       throw new Error(
-        'repo_token does not have enough permissions to access workflow API'
+        'REPO_TOKEN does not have enough permissions to access workflow API'
       );
     }
   }

--- a/src/cml.test.js
+++ b/src/cml.test.js
@@ -13,7 +13,7 @@ describe('Github tests', () => {
     jest.resetModules();
 
     process.env = {};
-    process.env.repo_token = TOKEN;
+    process.env.REPO_TOKEN = TOKEN;
   });
 
   afterAll(() => {
@@ -91,7 +91,7 @@ describe('Gitlab tests', () => {
     jest.resetModules();
 
     process.env = {};
-    process.env.repo_token = TOKEN;
+    process.env.REPO_TOKEN = TOKEN;
   });
 
   afterAll(() => {


### PR DESCRIPTION
Because consistency with naming conventions is nice.