### PR TITLE
Enforce strict argument parsing

### DIFF
--- a/bin/cml-pr.js
+++ b/bin/cml-pr.js
@@ -16,6 +16,7 @@ const run = async (opts) => {
 
 const opts = decamelize(
   yargs
+    .strict()
     .usage('Usage: $0 <path to markdown file>')
     .describe('md', 'Output in markdown format [](url).')
     .boolean('md')

--- a/bin/cml-publish.js
+++ b/bin/cml-publish.js
@@ -37,6 +37,7 @@ const run = async (opts) => {
 pipe_args.load('binary');
 const data = pipe_args.piped_arg();
 const argv = yargs
+  .strict()
   .usage(`Usage: $0 <path to file>`)
   .describe('md', 'Output in markdown format [title || name](url).')
   .boolean('md')

--- a/bin/cml-runner.js
+++ b/bin/cml-runner.js
@@ -315,6 +315,7 @@ const run = async (opts) => {
 
 const opts = decamelize(
   yargs
+    .strict()
     .usage(`Usage: $0`)
     .default('labels', RUNNER_LABELS)
     .describe(

--- a/bin/cml-send-comment.js
+++ b/bin/cml-send-comment.js
@@ -25,6 +25,7 @@ const run = async (opts) => {
 };
 
 const argv = yargs
+  .strict()
   .usage('Usage: $0 <path to markdown file>')
   .default('commit-sha')
   .describe(

--- a/bin/cml-send-github-check.js
+++ b/bin/cml-send-github-check.js
@@ -18,6 +18,7 @@ const run = async (opts) => {
 };
 
 const argv = yargs
+  .strict()
   .usage('Usage: $0 <path to markdown file>')
   .default('head-sha')
   .describe(

--- a/bin/cml-tensorboard-dev.js
+++ b/bin/cml-tensorboard-dev.js
@@ -92,6 +92,7 @@ const run = async (opts) => {
 };
 
 const argv = yargs
+  .strict()
   .usage(`Usage: $0`)
   .default('credentials')
   .describe(


### PR DESCRIPTION
Previously, yargs was silently ignoring unknown arguments and producing esoteric bugs on edge cases: `--option ---ARGUMENT---` doesn't produce the same result as `--option=---ARGUMENT---` but would be silently parsed without the strict mode.