### PR TITLE
Use actions/setup-node to configure the npm token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          registry-url: https://registry.npmjs.org
       - run: npm install
       - run: npm publish
         env:


### PR DESCRIPTION
Adding [`actions/setup-node`](https://github.com/actions/setup-node) as a pre-publish step with an explicit `registry-url` will set the `NPM_CONFIG_USERCONFIG` environment variable so it points to an automatically generated file that will cause future `npm` commands to interpret the `NODE_AUTH_TOKEN` environment variable as expected. 😵 

Should fix [this workflow error](https://github.com/iterative/cml/runs/2545606877?check_suite_focus=true#step:4:78) on future runs.