### PR TITLE
Remove stray underscore in Docker Hub secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - uses: docker/login-action@v1
         with:
           registry: ghcr.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,8 @@ jobs:
       - uses: docker/login-action@v1
         with:
           registry: docker.io
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: docker/login-action@v1
         with:
           registry: ghcr.io


### PR DESCRIPTION
My original workflow used an underscore to separate `DOCKER_HUB` on registry secrets because that was how I named them on the old staging fork, but secrets on this repository don't use the first underscore and use `PASSWORD` instead of `TOKEN` for the latter. 🤦  

https://github.com/iterative/cml/blob/debcae1cee2bf485700adeb99eb1864122cc5aae/.github/workflows/publish.yml#L80-L81