### PR TITLE
Fix pipe reading logic on Windows

### DIFF
--- a/src/pipe-args.js
+++ b/src/pipe-args.js
@@ -24,6 +24,7 @@ module.exports.load = (format) => {
 
       chunks.push(buffer.slice(0, nbytes));
     } catch (err) {
+      if (err.code === 'EOF') break; // HACK: see nodejs/node#35997
       if (err.code !== 'EAGAIN') throw err;
     }
   }


### PR DESCRIPTION
The fs.readSync function throws EOF instead of returning 0 like in other systems.
See nodejs/node#35997 for more information.