### PR TITLE
No git sha dependencies

### DIFF
--- a/bin/cml-send-comment.js
+++ b/bin/cml-send-comment.js
@@ -4,59 +4,50 @@ console.log = console.error;
 
 const fs = require('fs').promises;
 const yargs = require('yargs');
+const decamelize = require('decamelize-keys');
 
 const CML = require('../src/cml');
 
 const run = async (opts) => {
-  const {
-    'commit-sha': sha,
-    'head-sha': head_sha,
-    'rm-watermark': rm_watermark
-  } = opts;
   const path = opts._[0];
   const report = await fs.readFile(path, 'utf-8');
-
   const cml = new CML(opts);
-  await cml.comment_create({
-    report,
-    commit_sha: sha || head_sha,
-    rm_watermark
-  });
+  await cml.comment_create({ ...opts, report });
 };
 
-const argv = yargs
-  .strict()
-  .usage('Usage: $0 <path to markdown file>')
-  .default('commit-sha')
-  .describe(
-    'commit-sha',
-    'Commit SHA linked to this comment. Defaults to HEAD.'
-  )
-  .default('head-sha')
-  .describe('head-sha', 'Commit SHA linked to this comment. Defaults to HEAD.')
-  .deprecateOption('head-sha', 'Use commit-sha instead')
-  .boolean('rm-watermark')
-  .describe(
-    'rm-watermark',
-    'Avoid watermark. CML needs a watermark to be able to distinguish CML reports from other comments in order to provide extra functionality.'
-  )
-  .default('repo')
-  .describe(
-    'repo',
-    'Specifies the repo to be used. If not specified is extracted from the CI ENV.'
-  )
-  .default('token')
-  .describe(
-    'token',
-    'Personal access token to be used. If not specified in extracted from ENV REPO_TOKEN.'
-  )
-  .default('driver')
-  .choices('driver', ['github', 'gitlab'])
-  .describe('driver', 'If not specify it infers it from the ENV.')
-  .help('h')
-  .demand(1).argv;
+const opts = decamelize(
+  yargs
+    .strict()
+    .usage('Usage: $0 <path to markdown file>')
+    .default('commit-sha')
+    .describe(
+      'commit-sha',
+      'Commit SHA linked to this comment. Defaults to HEAD.'
+    )
+    .alias('commit-sha', 'head-sha')
+    .boolean('rm-watermark')
+    .describe(
+      'rm-watermark',
+      'Avoid watermark. CML needs a watermark to be able to distinguish CML reports from other comments in order to provide extra functionality.'
+    )
+    .default('repo')
+    .describe(
+      'repo',
+      'Specifies the repo to be used. If not specified is extracted from the CI ENV.'
+    )
+    .default('token')
+    .describe(
+      'token',
+      'Personal access token to be used. If not specified in extracted from ENV REPO_TOKEN.'
+    )
+    .default('driver')
+    .choices('driver', ['github', 'gitlab'])
+    .describe('driver', 'If not specify it infers it from the ENV.')
+    .help('h')
+    .demand(1).argv
+);
 
-run(argv).catch((e) => {
+run(opts).catch((e) => {
   console.error(e);
   process.exit(1);
 });

--- a/bin/cml-send-comment.test.js
+++ b/bin/cml-send-comment.test.js
@@ -19,20 +19,18 @@ describe('Comment integration tests', () => {
       "Usage: cml-send-comment.js <path to markdown file>
 
       Options:
-        --version       Show version number                                  [boolean]
-        --commit-sha    Commit SHA linked to this comment. Defaults to HEAD.
-        --head-sha      Commit SHA linked to this comment. Defaults to HEAD.
-                                                  [deprecated: Use commit-sha instead]
-        --rm-watermark  Avoid watermark. CML needs a watermark to be able to
-                        distinguish CML reports from other comments in order to
-                        provide extra functionality.                         [boolean]
-        --repo          Specifies the repo to be used. If not specified is extracted
-                        from the CI ENV.
-        --token         Personal access token to be used. If not specified in
-                        extracted from ENV REPO_TOKEN.
-        --driver        If not specify it infers it from the ENV.
+        --version                 Show version number                        [boolean]
+        --commit-sha, --head-sha  Commit SHA linked to this comment. Defaults to HEAD.
+        --rm-watermark            Avoid watermark. CML needs a watermark to be able to
+                                  distinguish CML reports from other comments in order
+                                  to provide extra functionality.            [boolean]
+        --repo                    Specifies the repo to be used. If not specified is
+                                  extracted from the CI ENV.
+        --token                   Personal access token to be used. If not specified
+                                  in extracted from ENV REPO_TOKEN.
+        --driver                  If not specify it infers it from the ENV.
                                                          [choices: \\"github\\", \\"gitlab\\"]
-        -h              Show help                                            [boolean]"
+        -h                        Show help                                  [boolean]"
     `);
   });
 

--- a/bin/cml-send-github-check.js
+++ b/bin/cml-send-github-check.js
@@ -4,52 +4,57 @@ console.log = console.error;
 
 const fs = require('fs').promises;
 const yargs = require('yargs');
+const decamelize = require('decamelize-keys');
 
 const CML = require('../src/cml');
 const CHECK_TITLE = 'CML Report';
 
 const run = async (opts) => {
-  const { 'head-sha': head_sha, conclusion, title } = opts;
   const path = opts._[0];
   const report = await fs.readFile(path, 'utf-8');
-
-  const cml = new CML({ ...opts, driver: 'github' });
-  await cml.check_create({ head_sha, report, conclusion, title });
+  const cml = new CML({ ...opts });
+  await cml.check_create({ ...opts, report });
 };
 
-const argv = yargs
-  .strict()
-  .usage('Usage: $0 <path to markdown file>')
-  .default('head-sha')
-  .describe(
-    'head-sha',
-    'Commit sha where the comment will appear. Defaults to HEAD.'
-  )
-  .default('conclusion', 'success', 'Sets the conclusion status of the check.')
-  .choices('conclusion', [
-    'success',
-    'failure',
-    'neutral',
-    'cancelled',
-    'skipped',
-    'timed_out'
-  ])
-  .default('title', CHECK_TITLE)
-  .describe('title', 'Sets title of the check.')
-  .default('repo')
-  .describe(
-    'repo',
-    'Specifies the repo to be used. If not specified is extracted from the CI ENV.'
-  )
-  .default('token')
-  .describe(
-    'token',
-    'Personal access token to be used. If not specified in extracted from ENV REPO_TOKEN.'
-  )
-  .help('h')
-  .demand(1).argv;
+const opts = decamelize(
+  yargs
+    .strict()
+    .usage('Usage: $0 <path to markdown file>')
+    .describe(
+      'commit-sha',
+      'Commit SHA linked to this comment. Defaults to HEAD.'
+    )
+    .alias('commit-sha', 'head-sha')
+    .default(
+      'conclusion',
+      'success',
+      'Sets the conclusion status of the check.'
+    )
+    .choices('conclusion', [
+      'success',
+      'failure',
+      'neutral',
+      'cancelled',
+      'skipped',
+      'timed_out'
+    ])
+    .default('title', CHECK_TITLE)
+    .describe('title', 'Sets title of the check.')
+    .default('repo')
+    .describe(
+      'repo',
+      'Specifies the repo to be used. If not specified is extracted from the CI ENV.'
+    )
+    .default('token')
+    .describe(
+      'token',
+      'Personal access token to be used. If not specified in extracted from ENV REPO_TOKEN.'
+    )
+    .help('h')
+    .demand(1).argv
+);
 
-run(argv).catch((e) => {
+run(opts).catch((e) => {
   console.error(e);
   process.exit(1);
 });

--- a/bin/cml-send-github-check.test.js
+++ b/bin/cml-send-github-check.test.js
@@ -39,14 +39,14 @@ describe('CML e2e', () => {
       "Usage: cml-send-github-check.js <path to markdown file>
 
       Options:
-        --version     Show version number                                    [boolean]
-        --head-sha    Commit sha where the comment will appear. Defaults to HEAD.
-        --title       Sets title of the check.                 [default: \\"CML Report\\"]
-        --repo        Specifies the repo to be used. If not specified is extracted
-                      from the CI ENV.
-        --token       Personal access token to be used. If not specified in extracted
-                      from ENV REPO_TOKEN.
-        -h            Show help                                              [boolean]
+        --version                 Show version number                        [boolean]
+        --commit-sha, --head-sha  Commit SHA linked to this comment. Defaults to HEAD.
+        --title                   Sets title of the check.     [default: \\"CML Report\\"]
+        --repo                    Specifies the repo to be used. If not specified is
+                                  extracted from the CI ENV.
+        --token                   Personal access token to be used. If not specified
+                                  in extracted from ENV REPO_TOKEN.
+        -h                        Show help                                  [boolean]
         --conclusion[choices: \\"success\\", \\"failure\\", \\"neutral\\", \\"cancelled\\", \\"skipped\\",
                       \\"timed_out\\"] [default: Sets the conclusion status of the check.]"
     `);


### PR DESCRIPTION
Send comment and check need to get the sha from git despite that it has been provided.
Additionally cml-send-check and cml-send-comment have been aligned with the use of ```commit-sha```

closes #478 
closes #274 