### PR TITLE
cml-pr prs list

### DIFF
--- a/src/cml.js
+++ b/src/cml.js
@@ -277,36 +277,31 @@ class CML {
     if (branch_exists) {
       const prs = await driver.prs();
       const { url } =
-        prs.find((pr) => pr.source === source && pr.target === target) || {};
+        prs.find(
+          (pr) => source.endsWith(pr.source) && target.endsWith(pr.target)
+        ) || {};
 
       if (url) return render_pr(url);
     } else {
-      try {
-        await exec(`git config --local user.email "${user_email}"`);
-        await exec(`git config --local user.name "${user_name}"`);
+      await exec(`git config --local user.email "${user_email}"`);
+      await exec(`git config --local user.name "${user_name}"`);
 
-        if (CI) {
-          if (this.driver === GITLAB) {
-            const repo = new URL(this.repo);
-            repo.password = this.token;
-            repo.username = driver.user_name;
+      if (CI) {
+        if (this.driver === GITLAB) {
+          const repo = new URL(this.repo);
+          repo.password = this.token;
+          repo.username = driver.user_name;
 
-            await exec(`git remote rm ${remote}`);
-            await exec(`git remote add ${remote} "${repo.toString()}.git"`);
-          }
+          await exec(`git remote rm ${remote}`);
+          await exec(`git remote add ${remote} "${repo.toString()}.git"`);
         }
-
-        // await exec(`git checkout -B ${target} ${sha}`);
-        await exec(`git checkout -b ${source}`);
-        await exec(`git add ${paths.join(' ')}`);
-        await exec(`git commit -m "CML PR for ${sha_short} [skip ci]"`);
-        await exec(`git push --set-upstream ${remote} ${source}`);
-        // await exec(`git checkout -B ${target} ${sha}`);
-      } catch (err) {
-        // await exec(`git checkout -B ${target} ${sha}`);
-        console.log(err);
-        throw err;
       }
+
+      await exec(`git checkout -B ${target} ${sha}`);
+      await exec(`git checkout -b ${source}`);
+      await exec(`git add ${paths.join(' ')}`);
+      await exec(`git commit -m "CML PR for ${sha_short} [skip ci]"`);
+      await exec(`git push --set-upstream ${remote} ${source}`);
     }
 
     const title = `CML PR for ${target} ${sha_short}`;

--- a/src/cml.js
+++ b/src/cml.js
@@ -296,14 +296,15 @@ class CML {
           }
         }
 
-        await exec(`git checkout -B ${target} ${sha}`);
+        // await exec(`git checkout -B ${target} ${sha}`);
         await exec(`git checkout -b ${source}`);
         await exec(`git add ${paths.join(' ')}`);
         await exec(`git commit -m "CML PR for ${sha_short} [skip ci]"`);
         await exec(`git push --set-upstream ${remote} ${source}`);
-        await exec(`git checkout -B ${target} ${sha}`);
+        // await exec(`git checkout -B ${target} ${sha}`);
       } catch (err) {
-        await exec(`git checkout -B ${target} ${sha}`);
+        // await exec(`git checkout -B ${target} ${sha}`);
+        console.log(err);
         throw err;
       }
     }


### PR DESCRIPTION
Something has changed in GH API PRs output that the branch names now includes refs.

 - Fixes the possibility or repeat cml-pr execution retuning existing pr
 - No useless try
 - Removed checkout back (made cml-pr to be always used after dvc and report creation)