### PR TITLE
cml-pr name branch

### DIFF
--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -21,8 +21,7 @@ const {
 const branch_name = (branch) => {
   if (!branch) return;
 
-  const parts = branch.split('/');
-  return parts[parts.length - 1] || branch;
+  return branch.replace('/refs/heads/', '');
 };
 
 const owner_repo = (opts) => {

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -18,6 +18,11 @@ const {
   GITHUB_EVENT_NAME
 } = process.env;
 
+const branch_name = (branch) => {
+  const parts = branch.split('/');
+  return parts[parts.length - 1] || branch;
+};
+
 const owner_repo = (opts) => {
   let owner, repo;
   const { uri } = opts;
@@ -276,8 +281,8 @@ class Github {
       } = pr;
       return {
         url,
-        source,
-        target
+        source: branch_name(source),
+        target: branch_name(target)
       };
     });
   }
@@ -290,7 +295,7 @@ class Github {
   }
 
   get branch() {
-    return GITHUB_REF;
+    return branch_name(GITHUB_REF);
   }
 
   get user_email() {

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -21,7 +21,7 @@ const {
 const branch_name = (branch) => {
   if (!branch) return;
 
-  return branch.replace('refs/heads/', '');
+  return branch.replace(/refs\/(head|tag)s\//, '');
 };
 
 const owner_repo = (opts) => {

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -19,6 +19,8 @@ const {
 } = process.env;
 
 const branch_name = (branch) => {
+  if (!branch) return;
+
   const parts = branch.split('/');
   return parts[parts.length - 1] || branch;
 };

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -21,7 +21,7 @@ const {
 const branch_name = (branch) => {
   if (!branch) return;
 
-  return branch.replace('/refs/heads/', '');
+  return branch.replace('refs/heads/', '');
 };
 
 const owner_repo = (opts) => {


### PR DESCRIPTION
GH gives branch names with all the ref ```/refs/heads/branch``` using branch name like this seems possible through their api but is breaking later on their UI
 
- Extracts the last part of the branch name
 
closes #551 