### PR TITLE
Unmask catch-all token exceptions

### DIFF
--- a/src/cml.js
+++ b/src/cml.js
@@ -220,13 +220,7 @@ class CML {
   }
 
   async repo_token_check() {
-    try {
-      await this.runner_token();
-    } catch (err) {
-      throw new Error(
-        'REPO_TOKEN does not have enough permissions to access workflow API'
-      );
-    }
+    await this.runner_token();
   }
 
   async pr_create(opts = {}) {

--- a/src/cml.js
+++ b/src/cml.js
@@ -222,10 +222,10 @@ class CML {
   async repo_token_check() {
     try {
       await this.runner_token();
-    } catch (error) {
-      if (error.message === 'Bad credentials')
-        error.message += ', REPO_TOKEN should be a personal access token';
-      throw error;
+    } catch (err) {
+      if (err.message === 'Bad credentials')
+        err.message += ', REPO_TOKEN should be a personal access token';
+      throw err;
     }
   }
 

--- a/src/cml.js
+++ b/src/cml.js
@@ -220,7 +220,13 @@ class CML {
   }
 
   async repo_token_check() {
-    await this.runner_token();
+    try {
+      await this.runner_token();
+    } catch (error) {
+      if (error.message === 'Bad credentials') 
+        error.message += ', REPO_TOKEN should be a personal access token'
+      throw error
+    }   
   }
 
   async pr_create(opts = {}) {

--- a/src/cml.js
+++ b/src/cml.js
@@ -223,10 +223,10 @@ class CML {
     try {
       await this.runner_token();
     } catch (error) {
-      if (error.message === 'Bad credentials') 
-        error.message += ', REPO_TOKEN should be a personal access token'
-      throw error
-    }   
+      if (error.message === 'Bad credentials')
+        error.message += ', REPO_TOKEN should be a personal access token';
+      throw error;
+    }
   }
 
   async pr_create(opts = {}) {


### PR DESCRIPTION
Masking all the errors derived from this function is highly counterproductive in some edge cases. At least, `bad credentials` and `not found` are common but separate errors, and mixing them can lead to long and frustrating blind debugging sessions.

CML components rely heavily on services we don't control, and errors are hard to reproduce and hard to trace. While the happy path should be as pretty as possible for end users, errors should be as verbose as possible and contain as much useful non-sensitive information as we manage to extract.

As @DavidGOrtega suggested, we may also implement some sort of wrapper and print a few suggestions for the possible causes for each error, but outputting the original error message is a must.

### See also
* https://github.com/iterative/cml/issues/562#issuecomment-849132532, how this pull request converts a blind debugging nightmare into an immediate solution.
* https://github.com/iterative/cml/pull/554#issuecomment-847922485, extended discussion about the topic.