### PR TITLE
Mask token in Terraform state output

### DIFF
--- a/bin/cml-runner.js
+++ b/bin/cml-runner.js
@@ -195,7 +195,8 @@ const run_cloud = async (opts) => {
         if (!cloud_ssh_private_visible) {
           instance.attributes.ssh_private = '[MASKED]';
         }
-
+        
+        instance.attributes.token = '[MASKED]';
         console.log(JSON.stringify(instance));
       }
     }

--- a/bin/cml-runner.js
+++ b/bin/cml-runner.js
@@ -195,7 +195,7 @@ const run_cloud = async (opts) => {
         if (!cloud_ssh_private_visible) {
           instance.attributes.ssh_private = '[MASKED]';
         }
-        
+
         instance.attributes.token = '[MASKED]';
         console.log(JSON.stringify(instance));
       }


### PR DESCRIPTION
Currently, CI/CD platforms mask it from their logs without requiring us to do anything, but we should mask it on our side anyways.

The proper fix would be honoring the sensitive property of fields by using Terraform CDK as per #556 and outputting only what is needed with [output values](https://www.terraform.io/docs/language/values/outputs.html); e.g. the instance address. See https://github.com/iterative/terraform-provider-iterative/pull/92 and https://github.com/iterative/terraform-provider-iterative/pull/120 for more information.