### PR TITLE
Allow access to secrets for external contributors

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -7,6 +7,10 @@ on:
   pull_request_target:
 jobs:
   lint:
+    environment:
+      ${{ (github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.full_name != github.repository) &&
+      'test-external' || 'test-internal' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -4,23 +4,27 @@ on:
     - cron: 0 0 * * *
   release:
     types: [published]
-  pull_request:
+  pull_request_target:
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - uses: actions/setup-node@v2
       - run: npm ci
       - run: npm run lint
   test:
     environment:
-      ${{ (github.event_name == 'pull_request' &&
+      ${{ (github.event_name == 'pull_request_target' &&
       github.event.pull_request.head.repo.full_name != github.repository) &&
       'test-external' || 'test-internal' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - uses: actions/setup-node@v2
       - uses: actions/setup-python@v2
       - run: pip install tensorboard
@@ -42,6 +46,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - uses: actions/setup-node@v2
         with:
           registry-url: https://registry.npmjs.org
@@ -73,6 +79,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
           fetch-depth: 0
       - name: Metadata
         id: metadata

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -6,11 +6,14 @@ on:
     types: [published]
   pull_request_target:
 jobs:
-  lint:
+  authorize:
     environment:
       ${{ (github.event_name == 'pull_request_target' &&
       github.event.pull_request.head.repo.full_name != github.repository) &&
-      'test-external' || 'test-internal' }}
+      'external' || 'internal' }}
+    runs-on: ubuntu-latest
+  lint:
+    needs: authorize
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -20,10 +23,7 @@ jobs:
       - run: npm ci
       - run: npm run lint
   test:
-    environment:
-      ${{ (github.event_name == 'pull_request_target' &&
-      github.event.pull_request.head.repo.full_name != github.repository) &&
-      'test-external' || 'test-internal' }}
+    needs: authorize
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
I forgot to explicitly add access to secrets for external contributors with `pull_request_target` but now it should work as expected. Please keep in mind that approving the test-external environment on malicious pull requests may lead to token exfiltration among other niceties.