### PR TITLE
Add `cml-send-comment --update`

### DIFF
--- a/bin/cml-send-comment.js
+++ b/bin/cml-send-comment.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+const print = console.log;
 console.log = console.error;
 
 const fs = require('fs').promises;
@@ -11,7 +12,7 @@ const run = async (opts) => {
   const path = opts._[0];
   const report = await fs.readFile(path, 'utf-8');
   const cml = new CML(opts);
-  console.log(await cml.commentCreate({ ...opts, report }));
+  print(await cml.commentCreate({ ...opts, report }));
 };
 
 const opts = yargs

--- a/bin/cml-send-comment.js
+++ b/bin/cml-send-comment.js
@@ -44,7 +44,7 @@ const opts = yargs
     'Personal access token to be used. If not specified is extracted from ENV REPO_TOKEN.'
   )
   .default('driver')
-  .choices('driver', ['github', 'gitlab'])
+  .choices('driver', ['github', 'gitlab', 'bitbucket'])
   .describe('driver', 'If not specify it infers it from the ENV.')
   .help('h')
   .demand(1).argv;

--- a/bin/cml-send-comment.js
+++ b/bin/cml-send-comment.js
@@ -36,7 +36,7 @@ const opts = yargs
   .default('token')
   .describe(
     'token',
-    'Personal access token to be used. If not specified in extracted from ENV REPO_TOKEN.'
+    'Personal access token to be used. If not specified is extracted from ENV REPO_TOKEN.'
   )
   .default('driver')
   .choices('driver', ['github', 'gitlab'])

--- a/bin/cml-send-comment.js
+++ b/bin/cml-send-comment.js
@@ -11,7 +11,7 @@ const run = async (opts) => {
   const path = opts._[0];
   const report = await fs.readFile(path, 'utf-8');
   const cml = new CML(opts);
-  await cml.commentCreate({ ...opts, report });
+  console.log(await cml.commentCreate({ ...opts, report }));
 };
 
 const opts = yargs
@@ -23,6 +23,11 @@ const opts = yargs
     'Commit SHA linked to this comment. Defaults to HEAD.'
   )
   .alias('commit-sha', 'head-sha')
+  .boolean('update')
+  .describe(
+    'update',
+    'Update the last CML comment (if any) instead of creating a new one'
+  )
   .boolean('rm-watermark')
   .describe(
     'rm-watermark',

--- a/bin/cml-send-comment.test.js
+++ b/bin/cml-send-comment.test.js
@@ -21,6 +21,8 @@ describe('Comment integration tests', () => {
       Options:
         --version                 Show version number                        [boolean]
         --commit-sha, --head-sha  Commit SHA linked to this comment. Defaults to HEAD.
+        --update                  Update the last CML comment (if any) instead of
+                                  creating a new one                         [boolean]
         --rm-watermark            Avoid watermark. CML needs a watermark to be able to
                                   distinguish CML reports from other comments in order
                                   to provide extra functionality.            [boolean]
@@ -29,7 +31,7 @@ describe('Comment integration tests', () => {
         --token                   Personal access token to be used. If not specified
                                   is extracted from ENV REPO_TOKEN.
         --driver                  If not specify it infers it from the ENV.
-                                                         [choices: \\"github\\", \\"gitlab\\"]
+                                            [choices: \\"github\\", \\"gitlab\\", \\"bitbucket\\"]
         -h                        Show help                                  [boolean]"
     `);
   });

--- a/bin/cml-send-comment.test.js
+++ b/bin/cml-send-comment.test.js
@@ -27,7 +27,7 @@ describe('Comment integration tests', () => {
         --repo                    Specifies the repo to be used. If not specified is
                                   extracted from the CI ENV.
         --token                   Personal access token to be used. If not specified
-                                  in extracted from ENV REPO_TOKEN.
+                                  is extracted from ENV REPO_TOKEN.
         --driver                  If not specify it infers it from the ENV.
                                                          [choices: \\"github\\", \\"gitlab\\"]
         -h                        Show help                                  [boolean]"

--- a/src/cml.js
+++ b/src/cml.js
@@ -96,8 +96,11 @@ class CML {
     const {
       report: userReport,
       commitSha = await this.headSha(),
-      rmWatermark
+      rmWatermark,
+      update
     } = opts;
+    if (rmWatermark && update)
+      throw new Error('watermarks are mandatory for updateable comments');
     const watermark = rmWatermark
       ? ''
       : ' \n\n  ![CML watermark](https://raw.githubusercontent.com/iterative/cml/master/assets/watermark.svg)';
@@ -106,7 +109,8 @@ class CML {
     return await getDriver(this).commentCreate({
       ...opts,
       report,
-      commitSha
+      commitSha,
+      watermark
     });
   }
 

--- a/src/cml.test.js
+++ b/src/cml.test.js
@@ -1,5 +1,6 @@
 const CML = require('../src/cml').default;
 
+jest.setTimeout(40000);
 describe('Github tests', () => {
   const OLD_ENV = process.env;
 

--- a/src/drivers/bitbucket_cloud.js
+++ b/src/drivers/bitbucket_cloud.js
@@ -31,7 +31,8 @@ class BitBucketCloud {
       prs = await this.paginatedRequest({ endpoint: getPrEndpoint });
     } catch (err) {
       if (err.message === 'Not Found Resource not found')
-        err.message = 'Click \'Go to pull request\' on any commit details page to enable this API'
+        err.message =
+          "Click 'Go to pull request' on any commit details page to enable this API";
       throw err;
     }
 
@@ -61,7 +62,7 @@ class BitBucketCloud {
       }
     }
 
-        const commitEndpoint = `/repositories/${projectPath}/commit/${commitSha}/comments/`;
+    const commitEndpoint = `/repositories/${projectPath}/commit/${commitSha}/comments/`;
 
     const existingCommmit = (
       await this.paginatedRequest({ endpoint: commitEndpoint, method: 'GET' })
@@ -81,7 +82,7 @@ class BitBucketCloud {
         method: update && existingCommmit ? 'PUT' : 'POST',
         body: JSON.stringify({ content: { raw: report } })
       })
-    ).links.html.href;    
+    ).links.html.href;
   }
 
   async checkCreate() {

--- a/src/drivers/bitbucket_cloud.js
+++ b/src/drivers/bitbucket_cloud.js
@@ -52,7 +52,11 @@ class BitBucketCloud {
       const getPrEndpoint = `/repositories/${projectPath}/commit/${commitSha}/pullrequests`;
       prs = await this.paginatedRequest({ endpoint: getPrEndpoint });
     } catch (err) {
-      if (err.message !== 'Not Found Resource not found') throw err;
+      if (err.message === 'Not Found Resource not found')
+        console.warn(
+          "Can't create a pull request comment: the Pull Request Commit Links application has not been installed."
+        );
+      else throw err;
     }
 
     if (prs && prs.length) {

--- a/src/drivers/bitbucket_cloud.js
+++ b/src/drivers/bitbucket_cloud.js
@@ -201,18 +201,18 @@ class BitBucketCloud {
 
   async paginatedRequest(opts = {}) {
     const { method = 'GET', body } = opts;
-    const result = await this.request(opts);
+    const {next, values} = await this.request(opts);
 
-    if (result.next) {
-      const next = await this.paginatedRequest({
-        url: result.next,
+    if (next) {
+      const nextValues = await this.paginatedRequest({
+        url: next,
         method,
         body
       });
-      result.values.push(...next);
+      values.push(...nextValues);
     }
 
-    return result.values;
+    return values;
   }
 
   get sha() {

--- a/src/drivers/bitbucket_cloud.js
+++ b/src/drivers/bitbucket_cloud.js
@@ -40,7 +40,7 @@ class BitBucketCloud {
       for (const pr of prs) {
         // Append a watermark to the report with a link to the commit
         const commitLink = commitSha.substr(0, 7);
-        const longReport = `${commitLink}   \n${report}`;
+        const longReport = `${commitLink}\n\n${report}`;
         const prBody = JSON.stringify({ content: { raw: longReport } });
 
         // Write a comment on the PR

--- a/src/drivers/bitbucket_cloud.js
+++ b/src/drivers/bitbucket_cloud.js
@@ -184,10 +184,11 @@ class BitBucketCloud {
       'Content-Type': 'application/json',
       Authorization: 'Basic ' + `${token}`
     };
-    const response = await fetch(
-      url || `${api}${endpoint}`,
-      { method, headers, body }
-    );
+    const response = await fetch(url || `${api}${endpoint}`, {
+      method,
+      headers,
+      body
+    });
 
     if (response.status > 300) {
       const {
@@ -201,7 +202,7 @@ class BitBucketCloud {
 
   async paginatedRequest(opts = {}) {
     const { method = 'GET', body } = opts;
-    const {next, values} = await this.request(opts);
+    const { next, values } = await this.request(opts);
 
     if (next) {
       const nextValues = await this.paginatedRequest({

--- a/src/drivers/bitbucket_cloud.js
+++ b/src/drivers/bitbucket_cloud.js
@@ -177,15 +177,17 @@ class BitBucketCloud {
 
   async request(opts = {}) {
     const { token, api } = this;
-    const { fullEndpoint, endpoint, method = 'GET', body } = opts;
-    if (!(endpoint || fullEndpoint))
+    const { url, endpoint, method = 'GET', body } = opts;
+    if (!(url || endpoint))
       throw new Error('BitBucket Cloud API endpoint not found');
     const headers = {
       'Content-Type': 'application/json',
       Authorization: 'Basic ' + `${token}`
     };
-    const url = fullEndpoint || `${api}${endpoint}`;
-    const response = await fetch(url, { method, headers, body });
+    const response = await fetch(
+      url || `${api}${endpoint}`,
+      { method, headers, body }
+    );
 
     if (response.status > 300) {
       const {
@@ -203,7 +205,7 @@ class BitBucketCloud {
 
     if (result.next) {
       const next = await this.paginatedRequest({
-        fullEndpoint: result.next,
+        url: result.next,
         method,
         body
       });

--- a/src/drivers/bitbucket_cloud.js
+++ b/src/drivers/bitbucket_cloud.js
@@ -29,10 +29,10 @@ class BitBucketCloud {
     const existingCommmit = (
       await this.paginatedRequest({ endpoint: commitEndpoint, method: 'GET' })
     )
-      .filter(
-        (comment) =>
-          comment.content.raw && comment.content.raw.endsWith(watermark)
-      )
+      .filter((comment) => {
+        const { content: { raw = '' } = {} } = comment;
+        return raw.endsWith(watermark);
+      })
       .sort((first, second) => first.id < second.id)
       .pop();
 
@@ -71,10 +71,10 @@ class BitBucketCloud {
         const existingPr = (
           await this.paginatedRequest({ endpoint: prEndpoint, method: 'GET' })
         )
-          .filter(
-            (comment) =>
-              comment.content.raw && comment.content.raw.endsWith(watermark)
-          )
+          .filter((comment) => {
+            const { content: { raw = '' } = {} } = comment;
+            return raw.endsWith(watermark);
+          })
           .sort((first, second) => first.id < second.id)
           .pop();
         await this.request({

--- a/src/drivers/bitbucket_cloud.test.js
+++ b/src/drivers/bitbucket_cloud.test.js
@@ -1,4 +1,4 @@
-jest.setTimeout(20000);
+jest.setTimeout(120000);
 const BitBucketCloud = require('./bitbucket_cloud');
 const {
   TEST_BBCLOUD_TOKEN: TOKEN,

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -72,10 +72,10 @@ class Github {
   async commentCreate(opts = {}) {
     const { report: body, commitSha, update, watermark } = opts;
 
-    const rest = octokit(this.token, this.repo);
+    const {paginate, repos } = octokit(this.token, this.repo);
 
     const existing = Object.values(
-      await rest.paginate(rest.repos.listCommentsForCommit, {
+      await paginate(repos.listCommentsForCommit, {
         ...ownerRepo({ uri: this.repo }),
         commit_sha: commitSha
       })
@@ -86,7 +86,7 @@ class Github {
 
     if (update && existing) {
       return (
-        await rest.repos.updateCommitComment({
+        await repos.updateCommitComment({
           ...ownerRepo({ uri: this.repo }),
           comment_id: existing.id,
           body
@@ -94,7 +94,7 @@ class Github {
       ).data.html_url;
     } else {
       return (
-        await rest.repos.createCommitComment({
+        await repos.createCommitComment({
           ...ownerRepo({ uri: this.repo }),
           commit_sha: commitSha,
           body

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -72,7 +72,7 @@ class Github {
   async commentCreate(opts = {}) {
     const { report: body, commitSha, update, watermark } = opts;
 
-    const {paginate, repos } = octokit(this.token, this.repo);
+    const { paginate, repos } = octokit(this.token, this.repo);
 
     const existing = Object.values(
       await paginate(repos.listCommentsForCommit, {

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -80,7 +80,10 @@ class Github {
         commit_sha: commitSha
       })
     )
-      .filter((comment) => comment.body && comment.body.endsWith(watermark))
+      .filter((comment) => {
+        const { body = '' } = comment;
+        return body.endsWith(watermark);
+      })
       .sort((first, second) => first.id < second.id)
       .pop();
 

--- a/src/drivers/github.test.js
+++ b/src/drivers/github.test.js
@@ -1,4 +1,4 @@
-jest.setTimeout(20000);
+jest.setTimeout(40000);
 
 const GithubClient = require('./github');
 

--- a/src/drivers/gitlab.js
+++ b/src/drivers/gitlab.js
@@ -71,7 +71,9 @@ class Gitlab {
   }
 
   async commentCreate(opts = {}) {
-    const { commitSha, report } = opts;
+    const { commitSha, report, update } = opts;
+
+    if (update) throw new Error('GitLab does not support comment updates!');
 
     const projectPath = await this.projectPath();
     const endpoint = `/projects/${projectPath}/repository/commits/${commitSha}/comments`;


### PR DESCRIPTION
Running `cml-send-comment` with the newly introduced `--update` flag will update the last CML comment instead of creating a new one. Comment authorship is determined by checking an invisible _watermark_ [sic] added by CML to every machine-made comment. Watermarks are just void images appended with Markdown at the end of comments.

### Supported platforms

- [X] GitHub
- [ ] GitLab<sup>1</sup>
- [X] Bitbucket<sup>2</sup>

***

<sup>1</sup> Blocked by [gitlab-org/gitlab#333000](https://gitlab.com/gitlab-org/gitlab/-/issues/333000); there is no known workaround.
<sup>2</sup> Requires user interaction for the first time, as per https://github.com/iterative/cml/pull/581#issuecomment-861898718.