### PR TITLE
ssh_private is valid in TF

### DIFF
--- a/bin/cml-runner.js
+++ b/bin/cml-runner.js
@@ -192,7 +192,7 @@ const runCloud = async (opts) => {
         const instance = instances[j];
 
         if (!cloudSshPrivateVisible) {
-          instance.attributes.sshPrivate = '[MASKED]';
+          instance.attributes.ssh_private = '[MASKED]';
         }
 
         instance.attributes.token = '[MASKED]';


### PR DESCRIPTION
We are masking a non correct member. Json is generated by Terraform and the value is ssh_private