### PR TITLE
Hotfix Expose terraform aws_security_group param

### DIFF
--- a/bin/cml-runner.js
+++ b/bin/cml-runner.js
@@ -134,6 +134,7 @@ const runCloud = async (opts) => {
       cloudSpot: spot,
       cloudSpotPrice: spotPrice,
       cloudStartupScript: startupScript,
+      cloudAwsSecurityGroup: awsSecurityGroup,
       tfFile,
       workdir
     } = opts;
@@ -165,7 +166,8 @@ const runCloud = async (opts) => {
         sshPrivate,
         spot,
         spotPrice,
-        startupScript
+        startupScript,
+        awsSecurityGroup
       });
     }
 
@@ -394,6 +396,8 @@ const opts = yargs
     'cloud-startup-script',
     'Run the provided Base64-encoded Linux shell script during the instance initialization'
   )
+  .default('cloud-aws-security-group', '')
+  .describe('cloud-aws-security-group', 'Specifies the security group in AWS')
   .default('tf-resource')
   .hide('tf-resource')
   .alias('tf-resource', 'tf_resource')

--- a/src/terraform.js
+++ b/src/terraform.js
@@ -79,7 +79,8 @@ const iterativeCmlRunnerTpl = (opts = {}) => {
     sshPrivate,
     spot,
     spotPrice,
-    startupScript
+    startupScript,
+    awsSecurityGroup
   } = opts;
 
   return `
@@ -106,6 +107,7 @@ resource "iterative_cml_runner" "runner" {
   ${spot ? `spot = ${spot}` : ''}
   ${spotPrice ? `spot_price = ${spotPrice}` : ''}
   ${startupScript ? `startup_script = "${startupScript}"` : ''}
+  ${awsSecurityGroup ? `aws_security_group = "${awsSecurityGroup}"` : ''}
 }
 `;
 };

--- a/src/terraform.test.js
+++ b/src/terraform.test.js
@@ -34,6 +34,7 @@ describe('Terraform tests', () => {
         
         
         
+        
       }
       "
     `);
@@ -55,7 +56,8 @@ describe('Terraform tests', () => {
       hddSize: 50,
       sshPrivate: 'myprivate',
       spot: true,
-      spotPrice: '0.0001'
+      spotPrice: '0.0001',
+      awsSecurityGroup: 'mysg'
     });
     expect(output).toMatchInlineSnapshot(`
       "
@@ -88,6 +90,7 @@ describe('Terraform tests', () => {
         spot = true
         spot_price = 0.0001
         
+        aws_security_group = \\"mysg\\"
       }
       "
     `);
@@ -141,6 +144,7 @@ describe('Terraform tests', () => {
         ssh_private = \\"myprivate\\"
         spot = true
         spot_price = 0.0001
+        
         
       }
       "
@@ -197,6 +201,7 @@ describe('Terraform tests', () => {
         spot = true
         spot_price = 0.0001
         startup_script = \\"c3VkbyBlY2hvICdoZWxsbyB3b3JsZCcgPj4gL3Vzci9oZWxsby50eHQ=\\"
+        
       }
       "
     `);


### PR DESCRIPTION
Some users need to specify a different VPC. This can be done for AWS in our TPI via aws_security_group.
Example of usage:

```sh
cml-runner \
--cloud aws  \   
--cloud-region eu-west-2 \    
--cloud-type t2.micro  \  
--labels cml-test \
--cloud-aws-security-group launch-wizard-1
```