### PR TITLE
Allow newlines in SSH private keys

### DIFF
--- a/bin/cml-runner.js
+++ b/bin/cml-runner.js
@@ -379,7 +379,7 @@ const opts = yargs
     'cloud-ssh-private',
     'Custom private RSA SSH key. If not provided an automatically generated throwaway key will be used'
   )
-  .coerce('cloud-ssh-private', (val) => val.replace(/\n/g, '\\n')
+  .coerce('cloud-ssh-private', (val) => val.replace(/\n/g, '\\n'))
   .boolean('cloud-ssh-private-visible')
   .describe(
     'cloud-ssh-private-visible',

--- a/bin/cml-runner.js
+++ b/bin/cml-runner.js
@@ -163,7 +163,7 @@ const runCloud = async (opts) => {
         type,
         gpu: gpu === 'tesla' ? 'v100' : gpu,
         hddSize,
-        sshPrivate.replace(/\n/g, '\\n'),
+        sshPrivate,
         spot,
         spotPrice,
         startupScript,
@@ -379,6 +379,7 @@ const opts = yargs
     'cloud-ssh-private',
     'Custom private RSA SSH key. If not provided an automatically generated throwaway key will be used'
   )
+  .coerce('cloud-ssh-private', (val) => val.replace(/\n/g, '\\n')
   .boolean('cloud-ssh-private-visible')
   .describe(
     'cloud-ssh-private-visible',

--- a/bin/cml-runner.js
+++ b/bin/cml-runner.js
@@ -163,7 +163,7 @@ const runCloud = async (opts) => {
         type,
         gpu: gpu === 'tesla' ? 'v100' : gpu,
         hddSize,
-        sshPrivate,
+        sshPrivate.replace(/\n/g, '\\n'),
         spot,
         spotPrice,
         startupScript,


### PR DESCRIPTION
This pull request simplifies the SSH key format requirements so users can provide keys directly without having to escape newlines on their own.

#### Before
```console
$ cml-runner --cloud-ssh-private="$(perl -pe 's/\n/\\n/g' key.pem)"
```

#### After
```console
$ cml-runner --cloud-ssh-private="$(cat key.pem)"
```