### PR TITLE
Fix endpoint detection logic, broken on FetchError

### DIFF
--- a/src/drivers/gitlab.js
+++ b/src/drivers/gitlab.js
@@ -60,7 +60,7 @@ class Gitlab {
     );
 
     this.detectedBase = possibleBases.find(
-      (base) => base.constructor !== Error
+      (base) => typeof base === 'string'
     );
     if (!this.detectedBase) {
       if (possibleBases.length) throw possibleBases[0];

--- a/src/drivers/gitlab.js
+++ b/src/drivers/gitlab.js
@@ -59,9 +59,7 @@ class Gitlab {
         })
     );
 
-    this.detectedBase = possibleBases.find(
-      (base) => typeof base === 'string'
-    );
+    this.detectedBase = possibleBases.find((base) => typeof base === 'string');
     if (!this.detectedBase) {
       if (possibleBases.length) throw possibleBases[0];
       throw new Error('Invalid repository address');


### PR DESCRIPTION
Detecting errors other than the vanilla `Error` isn't especially easy nor reliable, or so it seems. Given that we only return errors and strings, it's easier to consider as an error everything that isn't a string.