### PR TITLE
docs: rework README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@
 
 **What is CML?** Continuous Machine Learning (CML) is an open-source CLI tool
 for implementing continuous integration & delivery (CI/CD) with a focus on
-MLOps. Use it to automate parts of development workflows — including machine
-provisioning; model training and evaluation; comparing ML experiments across
+MLOps. Use it to automate development workflows — including machine
+provisioning, model training and evaluation, comparing ML experiments across
 project history, and monitoring changing datasets.
 
-For example, on every pull request CML can help to automatically train and
-evaluate models, then generate a visual report with results and metrics.
+CML can help train and evaluate models — and then generate a visual report with
+results and metrics — automatically on every pull request.
 
 ![](https://static.iterative.ai/img/cml/github_cloud_case_lessshadow.png) _An
 example report for a
@@ -40,9 +40,9 @@ CML principles:
 [YouTube video series](https://www.youtube.com/playlist?list=PL7WG7YrwYcnDBDuCkFbcyjnZQrdskFsBz)
 for hands-on MLOps tutorials using CML!
 
-## Table of contents
+## Table of Contents
 
-1. [Setup (GitLab, Bitbucket, GitHub)](#setup)
+1. [Setup (GitLab, GitHub, Bitbucket)](#setup)
 2. [Usage](#usage)
 3. [Getting started (tutorial)](#getting-started)
 4. [Using CML with DVC](#using-cml-with-dvc)
@@ -51,7 +51,7 @@ for hands-on MLOps tutorials using CML!
 
 ## Setup
 
-You'll need a GitLab, Bitbucket, or GitHub account to begin. Users may wish to
+You'll need a GitLab, GitHub, or Bitbucket account to begin. Users may wish to
 familiarize themselves with [Github Actions](https://help.github.com/en/actions)
 or
 [GitLab CI/CD](https://about.gitlab.com/stages-devops-lifecycle/continuous-integration).
@@ -126,7 +126,7 @@ CML provides a number of functions to help package the outputs of ML workflows
 report.
 
 Below is a table of CML functions for writing markdown reports and delivering
-those reports to your CI system (GitLab CI/CD or GitHub Actions).
+those reports to your CI system.
 
 | Function                | Description                                                      | Example Inputs                                              |
 | ----------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------- |
@@ -454,6 +454,8 @@ newly-launched instance.
 > such `cml-send-comment` from your instance, you can create your favourite
 > training environment in the cloud by pulling the Docker container of your
 > choice.
+
+#### Docker Images
 
 We like the CML container (`docker://dvcorg/cml`) because it comes loaded with
 Python, CUDA, `git`, `node` and other essentials for full-stack data science.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ CML principles:
   plots in each Git pull request. Rigorous engineering practices help your team
   make informed, data-driven decisions.
 - **No additional services.** Build your own ML platform using GitLab, GitHub,
-  or BitBucket. Optionally, use
+  or Bitbucket. Optionally, use
   [cloud storage](#configuring-cloud-storage-providers) as well as either
   self-hosted or cloud runners (such as AWS EC2, Azure, or GCP). No databases,
   services or complex setup needed.
@@ -42,7 +42,7 @@ for hands-on MLOps tutorials using CML!
 
 ## Table of contents
 
-1. [Setup (GitLab, GitHub, BitBucket)](#setup)
+1. [Setup (GitLab, GitHub, Bitbucket)](#setup)
 2. [Usage](#usage)
 3. [Getting started (tutorial)](#getting-started)
 4. [Using CML with DVC](#using-cml-with-dvc)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ CML principles:
 - **Auto reports for ML experiments.** Auto-generate reports with metrics and
   plots in each Git pull request. Rigorous engineering practices help your team
   make informed, data-driven decisions.
-- **No additional services.** Build your own ML platform using GitHub, GitLab,
+- **No additional services.** Build your own ML platform using GitLab, GitHub,
   or BitBucket. Optionally, use
   [cloud storage](#configuring-cloud-storage-providers) as well as either
   self-hosted or cloud runners (such as AWS EC2, Azure, or GCP). No databases,
@@ -42,13 +42,12 @@ for hands-on MLOps tutorials using CML!
 
 ## Table of contents
 
-1. [Setup](#setup)
+1. [Setup (GitLab, GitHub, BitBucket)](#setup)
 2. [Usage](#usage)
 3. [Getting started (tutorial)](#getting-started)
 4. [Using CML with DVC](#using-cml-with-dvc)
-5. [Using self-hosted runners](#using-self-hosted-runners)
-6. [Install CML as a package](#install-cml-as-a-package)
-7. [Example Projects](#see-also)
+5. [Advanced Setup (Self-hosted, local package)](#advanced-setup)
+6. [Example projects](#see-also)
 
 ## Setup
 
@@ -119,21 +118,21 @@ and CML set up on an Ubuntu LTS base with CUDA libraries and
 
 ### CML Functions
 
-CML provides a number of helper functions to help package the outputs of ML
-workflows (including numeric data and visualizations about model performance)
-into a CML report.
+CML provides a number of functions to help package the outputs of ML workflows
+(including numeric data and visualizations about model performance) into a CML
+report.
 
 Below is a table of CML functions for writing markdown reports and delivering
 those reports to your CI system (GitHub Actions or GitLab CI).
 
-| Function                | Description                                                    | Inputs                                                      |
-| ----------------------- | -------------------------------------------------------------- | ----------------------------------------------------------- |
-| `cml-runner`            | Starts a runner locally or in cloud providers                  | See [Arguments](https://github.com/iterative/cml#arguments) |
-| `cml-publish`           | Publish an image for writing to CML report.                    | `<path to image> --title <image title> --md`                |
-| `cml-send-comment`      | Return CML report as a comment in your GitHub/GitLab workflow. | `<path to report> --head-sha <sha>`                         |
-| `cml-send-github-check` | Return CML report as a check in GitHub                         | `<path to report> --head-sha <sha>`                         |
-| `cml-pr`                | Create a pull request.                                         | TODO                                                        |
-| `cml-tensorboard-dev`   | Return a link to a Tensorboard.dev page                        | `--logdir <path to logs> --title <experiment title> --md`   |
+| Function                | Description                                                      | Example Inputs                                              |
+| ----------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------- |
+| `cml-runner`            | Launch a runner locally or hosted by a cloud provider            | See [Arguments](https://github.com/iterative/cml#arguments) |
+| `cml-publish`           | Publicly host an image for displaying in a CML report            | `<path to image> --title <image title> --md`                |
+| `cml-send-comment`      | Return CML report as a comment in your GitHub/GitLab workflow    | `<path to report> --head-sha <sha>`                         |
+| `cml-send-github-check` | Return CML report as a check in GitHub                           | `<path to report> --head-sha <sha>`                         |
+| `cml-pr`                | Commit the given files to a new branch and create a pull request | `<path>...`                                                 |
+| `cml-tensorboard-dev`   | Return a link to a Tensorboard.dev page                          | `--logdir <path to logs> --title <experiment title> --md`   |
 
 #### CML Reports
 
@@ -160,7 +159,7 @@ report. For example, if `graph.png` is output by `python train.py`, run:
 cml-publish graph.png --md >> report.md
 ```
 
-## Getting Started
+### Getting Started
 
 1. Fork our
    [example project repository](https://github.com/iterative/example_cml).
@@ -214,13 +213,13 @@ git add . && git commit -m "modify forest depth"
 git push origin experiment
 ```
 
-5. In GitHub, open up a Pull Request to compare the `experiment` branch to
+5. In GitHub, open up a pull request to compare the `experiment` branch to
    `master`.
 
 ![](https://static.iterative.ai/img/cml/make_pr.png)
 
-Shortly, you should see a comment from `github-actions` appear in the Pull
-Request with your CML report. This is a result of the `cml-send-comment`
+Shortly, you should see a comment from `github-actions` appear in the pull
+request with your CML report. This is a result of the `cml-send-comment`
 function in your workflow.
 
 ![](https://static.iterative.ai/img/cml/first_report.png)
@@ -236,7 +235,7 @@ performance metrics and visualizations — in GitHub checks and comments. What
 kind of workflow you want to run, and want to put in your CML report, is up to
 you.
 
-## Using CML with DVC
+### Using CML with DVC
 
 In many ML projects, data isn't stored in a Git repository, but needs to be
 downloaded from external sources. [DVC](https://dvc.org) is a common way to
@@ -291,7 +290,7 @@ jobs:
 > :warning: If you're using DVC with cloud storage, take note of environment
 > variables for your storage format.
 
-### Configuring Cloud Storage Providers
+#### Configuring Cloud Storage Providers
 
 There are many
 [supported could storage providers](https://dvc.org/doc/command-reference/remote/modify#available-parameters-per-storage-type).
@@ -378,7 +377,9 @@ env:
 
 </details>
 
-## Setup: Self-hosted Runners
+## Advanced Setup
+
+### Self-hosted Runners
 
 GitHub Actions are run on GitHub-hosted runners by default. However, there are
 many great reasons to use your own runners: to take advantage of GPUs; to
@@ -389,7 +390,7 @@ data.
 > [official GitHub documentation](https://help.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners)
 > to get started setting up your own self-hosted runner.
 
-### Allocating cloud resources with CML
+#### Allocating Cloud Compute Resources with CML
 
 When a workflow requires computational resources (such as GPUs), CML can
 automatically allocate cloud instances using `cml-runner`. You can spin up
@@ -422,8 +423,8 @@ jobs:
           cml-runner \
               --cloud aws \
               --cloud-region us-west \
-              --cloud-type=t2.micro \
-              --labels=cml-runner
+              --cloud-type t2.micro \
+              --labels cml-runner
   model-training:
     needs: [deploy-runner]
     runs-on: [self-hosted, cml-runner]
@@ -446,10 +447,10 @@ instance in the `us-west` region. The `model-training` step then runs on the
 newly-launched instance.
 
 > :tada: **Note that you can use any container with this workflow!** While you
-> must [have CML and its dependencies set up](#install-cml-as-a-package) to use
-> functions such `cml-send-comment` from your instance, you can create your
-> favourite training environment in the cloud by pulling the Docker container of
-> your choice.
+> must [have CML and its dependencies set up](#local-package) to use functions
+> such `cml-send-comment` from your instance, you can create your favourite
+> training environment in the cloud by pulling the Docker container of your
+> choice.
 
 We like the CML container (`docker://dvcorg/cml`) because it comes loaded with
 Python, CUDA, `git`, `node` and other essentials for full-stack data science.
@@ -464,7 +465,7 @@ image tags. The tag convention is `{CML_VER}-dvc{DVC_VER}-base{BASE_VER}{-gpu}`:
 For example, `docker://dvcorg/cml:0-dvc2-base1-gpu`, or
 `docker://ghcr.io/iterative/cml:0-dvc2-base1`.
 
-### Arguments
+#### Arguments
 
 The `cml-runner` function accepts the following arguments:
 
@@ -519,10 +520,10 @@ Options:
   -h                           Show help                               [boolean]
 ```
 
-### Environment variables
+#### Environment Variables
 
 > :warning: You will need to
-> [create a personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line)
+> [create a personal access token (PAT)](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line)
 > with repository read/write access and workflow privileges. In the example
 > workflow, this token is stored as `PERSONAL_ACCESS_TOKEN`.
 
@@ -533,24 +534,23 @@ compute resources as secrets. In the above example, `AWS_ACCESS_KEY_ID` and
 Please see our docs about
 [configuring cloud storage providers](#configuring-cloud-storage-providers).
 
-### On-premise (local) runners
+#### On-premise (Local) Runners
 
 This means using on-premise machines as self-hosted runners. The `cml-runner`
 function is used to set up a local self-hosted runner. On your local machine or
-on-premise GPU cluster, [install CML as a package](#install-cml-as-a-package)
-and then run:
+on-premise GPU cluster, [install CML as a package](#local-package) and then run:
 
 ```bash
 cml-runner \
     --repo $your_project_repository_url \
-    --token=$PERSONAL_ACCESS_TOKEN \
+    --token $PERSONAL_ACCESS_TOKEN \
     --labels tf \
     --idle-timeout 180
 ```
 
 Now your machine will be listening for workflows from your project repository.
 
-## Install CML as a package
+### Local Package
 
 In the examples above, CML is installed by the `setup-cml` action, or comes
 pre-installed in a custom Docker image pulled by a CI runner. You can also
@@ -572,11 +572,11 @@ npm install -g vega-cli vega-lite
 CML and Vega-Lite package installation require the NodeJS package manager
 (`npm`) which ships with NodeJS. Installation instructions are below.
 
-### Install NodeJS in GitHub
+#### Install NodeJS
 
-This is probably not necessary when using GitHub's default containers or one of
-CML's Docker containers. Self-hosted runners may need to use a set up action to
-install NodeJS:
+- **GitHub**: This is probably not necessary when using GitHub's default
+  containers or one of CML's Docker containers. Self-hosted runners may need to
+  use a set up action to install NodeJS:
 
 ```bash
 uses: actions/setup-node@v2
@@ -584,9 +584,7 @@ uses: actions/setup-node@v2
     node-version: '12'
 ```
 
-### Install NodeJS in GitLab
-
-GitLab requires direct installation of NodeJS:
+- **GitLab**: Requires direct installation.
 
 ```bash
 curl -sL https://deb.nodesource.com/setup_12.x | bash
@@ -602,4 +600,7 @@ These are some example projects using CML.
 - [CML with DVC to pull data](https://github.com/iterative/cml_dvc_case)
 - [CML with Tensorboard](https://github.com/iterative/cml_tensorboard_case)
 - [CML with a small EC2 instance](https://github.com/iterative/cml-runner-base-case)
+  :key:
 - [CML with EC2 GPU](https://github.com/iterative/cml_cloud_case)
+
+:key: needs a [PAT](#environment-variables).

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ CML principles:
 - **Auto reports for ML experiments.** Auto-generate reports with metrics and
   plots in each Git pull request. Rigorous engineering practices help your team
   make informed, data-driven decisions.
-- **No additional services.** Build your own ML platform using GitLab, GitHub,
-  or Bitbucket. Optionally, use
+- **No additional services.** Build your own ML platform using GitLab,
+  Bitbucket, or GitHub. Optionally, use
   [cloud storage](#configuring-cloud-storage-providers) as well as either
   self-hosted or cloud runners (such as AWS EC2, Azure, or GCP). No databases,
   services or complex setup needed.
@@ -42,7 +42,7 @@ for hands-on MLOps tutorials using CML!
 
 ## Table of contents
 
-1. [Setup (GitLab, GitHub, Bitbucket)](#setup)
+1. [Setup (GitLab, Bitbucket, GitHub)](#setup)
 2. [Usage](#usage)
 3. [Getting started (tutorial)](#getting-started)
 4. [Using CML with DVC](#using-cml-with-dvc)
@@ -51,7 +51,7 @@ for hands-on MLOps tutorials using CML!
 
 ## Setup
 
-You'll need a GitHub, GitLab, or Bitbucket account to begin. Users may wish to
+You'll need a GitLab, Bitbucket, or GitHub account to begin. Users may wish to
 familiarize themselves with [Github Actions](https://help.github.com/en/actions)
 or
 [GitLab CI/CD](https://about.gitlab.com/stages-devops-lifecycle/continuous-integration).
@@ -126,13 +126,13 @@ CML provides a number of functions to help package the outputs of ML workflows
 report.
 
 Below is a table of CML functions for writing markdown reports and delivering
-those reports to your CI system (GitHub Actions or GitLab CI/CD).
+those reports to your CI system (GitLab CI/CD or GitHub Actions).
 
 | Function                | Description                                                      | Example Inputs                                              |
 | ----------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------- |
 | `cml-runner`            | Launch a runner locally or hosted by a cloud provider            | See [Arguments](https://github.com/iterative/cml#arguments) |
 | `cml-publish`           | Publicly host an image for displaying in a CML report            | `<path to image> --title <image title> --md`                |
-| `cml-send-comment`      | Return CML report as a comment in your GitHub/GitLab workflow    | `<path to report> --head-sha <sha>`                         |
+| `cml-send-comment`      | Return CML report as a comment in your GitLab/GitHub workflow    | `<path to report> --head-sha <sha>`                         |
 | `cml-send-github-check` | Return CML report as a check in GitHub                           | `<path to report> --head-sha <sha>`                         |
 | `cml-pr`                | Commit the given files to a new branch and create a pull request | `<path>...`                                                 |
 | `cml-tensorboard-dev`   | Return a link to a Tensorboard.dev page                          | `--logdir <path to logs> --title <experiment title> --md`   |

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ jobs:
     runs-on: [ubuntu-latest]
     # optionally use a convenient Ubuntu LTS + CUDA + DVC + CML image
     # container: docker://dvcorg/cml:0-dvc2-base1-gpu
+    # container: docker://ghcr.io/iterative/cml:0-dvc2-base1-gpu
     steps:
       - uses: actions/checkout@v2
       # may need to setup NodeJS & Python3 on e.g. self-hosted
@@ -111,9 +112,10 @@ jobs:
 We helpfully provide CML and other useful libraries pre-installed on our
 [custom Docker images](https://github.com/iterative/cml/blob/master/Dockerfile).
 In the above example, uncommenting the field
-`container: docker://dvcorg/cml:0-dvc2-base1-gpu` will make the GitHub Actions
-runner pull the CML Docker image. The image already has NodeJS, Python 3, DVC
-and CML set up on an Ubuntu LTS base with CUDA libraries and
+`container: docker://dvcorg/cml:0-dvc2-base1-gpu` (or
+`container: docker://ghcr.io/iterative/cml:0-dvc2-base1-gpu`) will make the
+GitHub Actions runner pull the CML Docker image. The image already has NodeJS,
+Python 3, DVC and CML set up on an Ubuntu LTS base with CUDA libraries and
 [Terraform](https://www.terraform.io) installed for convenience.
 
 ### CML Functions
@@ -252,7 +254,7 @@ on: [push]
 jobs:
   run:
     runs-on: [ubuntu-latest]
-    container: docker://dvcorg/cml:0-dvc2-base1
+    container: docker://ghcr.io/iterative/cml:0-dvc2-base1
     steps:
       - uses: actions/checkout@v2
       - name: Train model

--- a/README.md
+++ b/README.md
@@ -51,26 +51,27 @@ for hands-on MLOps tutorials using CML!
 
 ## Setup
 
-You'll need a GitHub or GitLab account to begin. Users may wish to familiarize
-themselves with [Github Actions](https://help.github.com/en/actions) or
+You'll need a GitHub, GitLab, or Bitbucket account to begin. Users may wish to
+familiarize themselves with [Github Actions](https://help.github.com/en/actions)
+or
 [GitLab CI/CD](https://about.gitlab.com/stages-devops-lifecycle/continuous-integration).
 Here, will discuss the GitHub use case.
 
 ### GitLab
 
 Please see our docs on
-[CML with GitLab](https://github.com/iterative/cml/wiki/CML-with-GitLab) and in
-particular the
+[CML with GitLab CI/CD](https://github.com/iterative/cml/wiki/CML-with-GitLab)
+and in particular the
 [personal access token](https://github.com/iterative/cml/wiki/CML-with-GitLab#variables)
 requirement.
 
-### Bitbucket Cloud
+### Bitbucket
 
 Please see our docs on
 [CML with Bitbucket Cloud](https://github.com/iterative/cml/wiki/CML-with-Bitbucket-Cloud).
 _Bitbucket Server support estimated to arrive by mid 2021._
 
-### GitHub Actions
+### GitHub
 
 The key file in any CML project is `.github/workflows/cml.yaml`:
 
@@ -114,8 +115,8 @@ We helpfully provide CML and other useful libraries pre-installed on our
 In the above example, uncommenting the field
 `container: docker://dvcorg/cml:0-dvc2-base1-gpu` (or
 `container: docker://ghcr.io/iterative/cml:0-dvc2-base1-gpu`) will make the
-GitHub Actions runner pull the CML Docker image. The image already has NodeJS,
-Python 3, DVC and CML set up on an Ubuntu LTS base with CUDA libraries and
+runner pull the CML Docker image. The image already has NodeJS, Python 3, DVC
+and CML set up on an Ubuntu LTS base with CUDA libraries and
 [Terraform](https://www.terraform.io) installed for convenience.
 
 ### CML Functions
@@ -125,7 +126,7 @@ CML provides a number of functions to help package the outputs of ML workflows
 report.
 
 Below is a table of CML functions for writing markdown reports and delivering
-those reports to your CI system (GitHub Actions or GitLab CI).
+those reports to your CI system (GitHub Actions or GitLab CI/CD).
 
 | Function                | Description                                                      | Example Inputs                                              |
 | ----------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -5,28 +5,32 @@
 [![GHA](https://img.shields.io/github/v/tag/iterative/setup-cml?label=GitHub%20Actions&logo=GitHub)](https://github.com/iterative/setup-cml)
 [![npm](https://img.shields.io/npm/v/@dvcorg/cml?logo=npm)](https://www.npmjs.com/package/@dvcorg/cml)
 
-**What is CML?** Continuous Machine Learning (CML) is an open-source library for
-implementing continuous integration & delivery (CI/CD) in machine learning
-projects. Use it to automate parts of your development workflow, including model
-training and evaluation, comparing ML experiments across your project history,
-and monitoring changing datasets.
+**What is CML?** Continuous Machine Learning (CML) is an open-source CLI tool
+for implementing continuous integration & delivery (CI/CD) with a focus on
+MLOps. Use it to automate parts of development workflows — including machine
+provisioning; model training and evaluation; comparing ML experiments across
+project history, and monitoring changing datasets.
 
-![](https://static.iterative.ai/img/cml/github_cloud_case_lessshadow.png) _On
-every pull request, CML helps you automatically train and evaluate models, then
-generates a visual report with results and metrics. Above, an example report for
-a [neural style transfer model](https://github.com/iterative/cml_cloud_case)._
+For example, on every pull request CML can help to automatically train and
+evaluate models, then generate a visual report with results and metrics.
 
-We built CML with these principles in mind:
+![](https://static.iterative.ai/img/cml/github_cloud_case_lessshadow.png) _An
+example report for a
+[neural style transfer model](https://github.com/iterative/cml_cloud_case)._
+
+CML principles:
 
 - **[GitFlow](https://nvie.com/posts/a-successful-git-branching-model/) for data
   science.** Use GitLab or GitHub to manage ML experiments, track who trained ML
   models or modified data and when. Codify data and models with
   [DVC](#using-cml-with-dvc) instead of pushing to a Git repo.
 - **Auto reports for ML experiments.** Auto-generate reports with metrics and
-  plots in each Git Pull Request. Rigorous engineering practices help your team
+  plots in each Git pull request. Rigorous engineering practices help your team
   make informed, data-driven decisions.
-- **No additional services.** Build your own ML platform using just GitHub or
-  GitLab and your favourite cloud services: AWS, Azure, GCP. No databases,
+- **No additional services.** Build your own ML platform using GitHub, GitLab,
+  or BitBucket. Optionally, use
+  [cloud storage](#configuring-cloud-storage-providers) as well as either
+  self-hosted or cloud runners (such as AWS EC2, Azure, or GCP). No databases,
   services or complex setup needed.
 
 :question: Need help? Just want to chat about continuous integration for ML?
@@ -38,27 +42,38 @@ for hands-on MLOps tutorials using CML!
 
 ## Table of contents
 
-1. [Usage](#usage)
-2. [Getting started (tutorial)](#getting-started)
-3. [Using CML with DVC](#using-cml-with-dvc)
-4. [Using self-hosted runners](#using-self-hosted-runners)
-5. [Install CML as a package](#install-cml-as-a-package)
-6. [Example Projects](#see-also)
+1. [Setup](#setup)
+2. [Usage](#usage)
+3. [Getting started (tutorial)](#getting-started)
+4. [Using CML with DVC](#using-cml-with-dvc)
+5. [Using self-hosted runners](#using-self-hosted-runners)
+6. [Install CML as a package](#install-cml-as-a-package)
+7. [Example Projects](#see-also)
 
-## Usage
+## Setup
 
 You'll need a GitHub or GitLab account to begin. Users may wish to familiarize
 themselves with [Github Actions](https://help.github.com/en/actions) or
 [GitLab CI/CD](https://about.gitlab.com/stages-devops-lifecycle/continuous-integration).
 Here, will discuss the GitHub use case.
 
-- **GitLab users**: Please see our
-  [docs about configuring CML with GitLab](https://github.com/iterative/cml/wiki/CML-with-GitLab).
-- **Bitbucket Cloud users**: Please see our
-  [docs on CML with Bitbucket Cloud](https://github.com/iterative/cml/wiki/CML-with-Bitbucket-Cloud).
-  _Bitbucket Server support estimated to arrive by May 2021._
-- **GitHub Actions users**: The key file in any CML project is
-  `.github/workflows/cml.yaml`:
+### GitLab
+
+Please see our docs on
+[CML with GitLab](https://github.com/iterative/cml/wiki/CML-with-GitLab) and in
+particular the
+[personal access token](https://github.com/iterative/cml/wiki/CML-with-GitLab#variables)
+requirement.
+
+### Bitbucket Cloud
+
+Please see our docs on
+[CML with Bitbucket Cloud](https://github.com/iterative/cml/wiki/CML-with-Bitbucket-Cloud).
+_Bitbucket Server support estimated to arrive by mid 2021._
+
+### GitHub Actions
+
+The key file in any CML project is `.github/workflows/cml.yaml`:
 
 ```yaml
 name: your-workflow-name
@@ -92,6 +107,8 @@ jobs:
           cml-send-comment report.md
 ```
 
+## Usage
+
 We helpfully provide CML and other useful libraries pre-installed on our
 [custom Docker images](https://github.com/iterative/cml/blob/master/Dockerfile).
 In the above example, uncommenting the field
@@ -118,12 +135,13 @@ those reports to your CI system (GitHub Actions or GitLab CI).
 | `cml-pr`                | Create a pull request.                                         | TODO                                                        |
 | `cml-tensorboard-dev`   | Return a link to a Tensorboard.dev page                        | `--logdir <path to logs> --title <experiment title> --md`   |
 
-### Customizing your CML report
+#### CML Reports
 
-CML reports are written in
-[GitHub Flavored Markdown](https://github.github.com/gfm/). That means they can
-contain images, tables, formatted text, HTML blocks, code snippets and more —
-really, what you put in a CML report is up to you. Some examples:
+The `cml-send-comment` command can be used to post reports. CML reports are
+written in [GitHub Flavored Markdown](https://github.github.com/gfm/). That
+means they can contain images, tables, formatted text, HTML blocks, code
+snippets and more — really, what you put in a CML report is up to you. Some
+examples:
 
 :spiral_notepad: **Text** Write to your report using whatever method you prefer.
 For example, copy the contents of a text file containing the results of ML model
@@ -273,7 +291,11 @@ jobs:
 > :warning: If you're using DVC with cloud storage, take note of environment
 > variables for your storage format.
 
-### Environment variables for supported cloud providers
+### Configuring Cloud Storage Providers
+
+There are many
+[supported could storage providers](https://dvc.org/doc/command-reference/remote/modify#available-parameters-per-storage-type).
+Here are a few examples for some of the most frequently used providers:
 
 <details>
   <summary>
@@ -356,7 +378,7 @@ env:
 
 </details>
 
-## Using self-hosted runners
+## Setup: Self-hosted Runners
 
 GitHub Actions are run on GitHub-hosted runners by default. However, there are
 many great reasons to use your own runners: to take advantage of GPUs; to
@@ -509,7 +531,7 @@ compute resources as secrets. In the above example, `AWS_ACCESS_KEY_ID` and
 `AWS_SECRET_ACCESS_KEY` are required to deploy EC2 instances.
 
 Please see our docs about
-[environment variables needed to authenticate with supported cloud services](#environment-variables-for-supported-cloud-providers).
+[configuring cloud storage providers](#configuring-cloud-storage-providers).
 
 ### On-premise (local) runners
 

--- a/README.md
+++ b/README.md
@@ -606,6 +606,6 @@ These are some example projects using CML.
 - [CML with Tensorboard](https://github.com/iterative/cml_tensorboard_case)
 - [CML with a small EC2 instance](https://github.com/iterative/cml-runner-base-case)
   :key:
-- [CML with EC2 GPU](https://github.com/iterative/cml_cloud_case)
+- [CML with EC2 GPU](https://github.com/iterative/cml_cloud_case) :key:
 
 :key: needs a [PAT](#environment-variables).

--- a/src/cml.js
+++ b/src/cml.js
@@ -6,7 +6,7 @@ const git = require('simple-git/promise')('./');
 
 const Gitlab = require('./drivers/gitlab');
 const Github = require('./drivers/github');
-const BitBucketCloud = require('./drivers/bitbucket_cloud');
+const BitbucketCloud = require('./drivers/bitbucket_cloud');
 const { upload, exec, watermarkUri } = require('./utils');
 
 const {
@@ -65,7 +65,7 @@ const getDriver = (opts) => {
 
   if (driver === GITHUB) return new Github({ repo, token });
   if (driver === GITLAB) return new Gitlab({ repo, token });
-  if (driver === BB) return new BitBucketCloud({ repo, token });
+  if (driver === BB) return new BitbucketCloud({ repo, token });
 
   throw new Error(`driver ${driver} unknown!`);
 };

--- a/src/drivers/bitbucket_cloud.js
+++ b/src/drivers/bitbucket_cloud.js
@@ -2,7 +2,7 @@ const fetch = require('node-fetch');
 const { URL } = require('url');
 
 const { BITBUCKET_COMMIT, BITBUCKET_BRANCH } = process.env;
-class BitBucketCloud {
+class BitbucketCloud {
   constructor(opts = {}) {
     const { repo, token } = opts;
 
@@ -86,31 +86,31 @@ class BitBucketCloud {
   }
 
   async checkCreate() {
-    throw new Error('BitBucket Cloud does not support check!');
+    throw new Error('Bitbucket Cloud does not support check!');
   }
 
   async upload(opts = {}) {
-    throw new Error('BitBucket Cloud does not support upload!');
+    throw new Error('Bitbucket Cloud does not support upload!');
   }
 
   async runnerToken() {
-    throw new Error('BitBucket Cloud does not support runnerToken!');
+    throw new Error('Bitbucket Cloud does not support runnerToken!');
   }
 
   async registerRunner(opts = {}) {
-    throw new Error('BitBucket Cloud does not support registerRunner!');
+    throw new Error('Bitbucket Cloud does not support registerRunner!');
   }
 
   async unregisterRunner(opts = {}) {
-    throw new Error('BitBucket Cloud does not support unregisterRunner!');
+    throw new Error('Bitbucket Cloud does not support unregisterRunner!');
   }
 
   async runnerByName(opts = {}) {
-    throw new Error('BitBucket Cloud does not support runnerByName!');
+    throw new Error('Bitbucket Cloud does not support runnerByName!');
   }
 
   async runnersByLabels(opts = {}) {
-    throw new Error('BitBucket Cloud does not support runner_by_labels!');
+    throw new Error('Bitbucket Cloud does not support runner_by_labels!');
   }
 
   async prCreate(opts = {}) {
@@ -176,7 +176,7 @@ class BitBucketCloud {
     const { token, api } = this;
     const { url, endpoint, method = 'GET', body } = opts;
     if (!(url || endpoint))
-      throw new Error('BitBucket Cloud API endpoint not found');
+      throw new Error('Bitbucket Cloud API endpoint not found');
     const headers = {
       'Content-Type': 'application/json',
       Authorization: 'Basic ' + `${token}`
@@ -226,4 +226,4 @@ class BitBucketCloud {
   get userName() {}
 }
 
-module.exports = BitBucketCloud;
+module.exports = BitbucketCloud;

--- a/src/drivers/bitbucket_cloud.test.js
+++ b/src/drivers/bitbucket_cloud.test.js
@@ -1,12 +1,12 @@
 jest.setTimeout(120000);
-const BitBucketCloud = require('./bitbucket_cloud');
+const BitbucketCloud = require('./bitbucket_cloud');
 const {
   TEST_BBCLOUD_TOKEN: TOKEN,
   TEST_BBCLOUD_REPO: REPO,
   TEST_BBCLOUD_SHA: SHA
 } = process.env;
 describe('Non Enviromental tests', () => {
-  const client = new BitBucketCloud({ repo: REPO, token: TOKEN });
+  const client = new BitbucketCloud({ repo: REPO, token: TOKEN });
   test('test repo and token', async () => {
     expect(client.repo).toBe(REPO);
     expect(client.token).toBe(TOKEN);
@@ -19,18 +19,18 @@ describe('Non Enviromental tests', () => {
   });
   test('Check', async () => {
     await expect(client.checkCreate()).rejects.toThrow(
-      'BitBucket Cloud does not support check!'
+      'Bitbucket Cloud does not support check!'
     );
   });
   test('Publish', async () => {
     const path = `${__dirname}/../../assets/logo.png`;
     await expect(client.upload({ path })).rejects.toThrow(
-      'BitBucket Cloud does not support upload!'
+      'Bitbucket Cloud does not support upload!'
     );
   });
   test('Runner token', async () => {
     await expect(client.runnerToken()).rejects.toThrow(
-      'BitBucket Cloud does not support runnerToken!'
+      'Bitbucket Cloud does not support runnerToken!'
     );
   });
 });


### PR DESCRIPTION
- [x] update sections
  - [x] create, simplify & unify installation/setup into just 2 sections (basic at top & advanced at bottom)
  - [x] more intuitive section names
- [x] document `cml-pr`
- [x] mark all "see also" examples which require PATs

----

- fixes #557

#### follow-up (after this PR)

- replace #cml-functions table with auto-generated collapsed command `--help` (#361)
- talk about runners after #583
  + transparent spot instances
  + avoid timeouts limitations
- maybe more reordering à la https://github.com/iterative/cml/pull/617#issuecomment-872151100
- review PAT necessity #625