### PR TITLE
Fix cml-pr reference handling for pull requests

### DIFF
--- a/src/cml.js
+++ b/src/cml.js
@@ -303,7 +303,7 @@ class CML {
         }
       }
 
-      await exec(`git fetch origin ${sha}`);
+      await exec(`git fetch ${remote} ${sha}`);
       await exec(`git checkout -B ${target} ${sha}`);
       await exec(`git checkout -b ${source}`);
       await exec(`git add ${paths.join(' ')}`);

--- a/src/cml.js
+++ b/src/cml.js
@@ -303,7 +303,7 @@ class CML {
         }
       }
 
-      await exec(`git fetch`);
+      await exec(`git fetch origin ${sha}`);
       await exec(`git checkout -B ${target} ${sha}`);
       await exec(`git checkout -b ${source}`);
       await exec(`git add ${paths.join(' ')}`);

--- a/src/cml.js
+++ b/src/cml.js
@@ -303,6 +303,7 @@ class CML {
         }
       }
 
+      await exec(`git fetch`);
       await exec(`git checkout -B ${target} ${sha}`);
       await exec(`git checkout -b ${source}`);
       await exec(`git add ${paths.join(' ')}`);

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -15,6 +15,7 @@ const {
   GITHUB_REPOSITORY,
   GITHUB_SHA,
   GITHUB_REF,
+  GITHUB_HEAD_REF,
   GITHUB_EVENT_NAME
 } = process.env;
 
@@ -318,7 +319,7 @@ class Github {
   }
 
   get branch() {
-    return branchName(GITHUB_REF);
+    return branchName(GITHUB_HEAD_REF || GITHUB_REF);
   }
 
   get userEmail() {


### PR DESCRIPTION
Workflows triggered with the [`pull_request`](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request) GitHub Actions event are going to have [`github.ref`](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context) set to one of the [pull references](https://git-scm.com/book/id/v2/GitHub-Maintaining-a-Project#_pr_refs) that GitHub creates for pull requests. We haven't noticed until now because all the tests were made using the [`push`](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#push) event.

We only consider `heads` and `tags` references and remove the first path components with a regular expression, and it works pretty well for these two kinds of references, but fails for the `pull` ones:
https://github.com/iterative/cml/blob/6c451d965aaea2ad2b1812dd2a223def9ce87739/src/drivers/github.js#L24

The most elegant solution I can think of would using a [short-circuit evaluation](https://en.wikipedia.org/wiki/Short-circuit_evaluation) fallback to [`GITHUB_HEAD_REF || GITHUB_REF`](https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables) so it doesn't have to deal with pull references at all.