### PR TITLE
Require runners to be online when honoring --reuse

### DIFF
--- a/bin/cml-runner.js
+++ b/bin/cml-runner.js
@@ -307,7 +307,10 @@ const run = async (opts) => {
     process.exit(0);
   }
 
-  if (reuse && (await cml.runnersByLabels({ labels })).find((runner) => runner.online)) {
+  if (
+    reuse &&
+    (await cml.runnersByLabels({ labels })).find((runner) => runner.online)
+  ) {
     console.log(`Reusing existing online runners with the ${labels} labels...`);
     process.exit(0);
   }

--- a/bin/cml-runner.js
+++ b/bin/cml-runner.js
@@ -307,8 +307,8 @@ const run = async (opts) => {
     process.exit(0);
   }
 
-  if (reuse && (await cml.runnersByLabels({ labels })).length > 0) {
-    console.log(`Reusing existing runners with the ${labels} labels...`);
+  if (reuse && (await cml.runnersByLabels({ labels })).find((runner) => runner.online)) {
+    console.log(`Reusing existing online runners with the ${labels} labels...`);
     process.exit(0);
   }
 

--- a/src/cml.js
+++ b/src/cml.js
@@ -218,12 +218,22 @@ class CML {
     return await getDriver(this).unregisterRunner(opts);
   }
 
+  async getRunners(opts = {}) {
+    return await getDriver(this).getRunners(opts);
+  }
+
   async runnerByName(opts = {}) {
-    return await getDriver(this).runnerByName(opts);
+    const { name } = opts;
+    const runners = await this.getRunners(opts);
+    return runners.find((runner) => runner.name === name);
   }
 
   async runnersByLabels(opts = {}) {
-    return await getDriver(this).runnersByLabels(opts);
+    const { labels } = opts;
+    const runners = await this.getRunners(opts);
+    return runners.filter((runner) =>
+      labels.split(',').every((label) => runner.labels.includes(label))
+    );
   }
 
   async repoTokenCheck() {

--- a/src/cml.test.js
+++ b/src/cml.test.js
@@ -1,6 +1,6 @@
 const CML = require('../src/cml').default;
 
-jest.setTimeout(40000);
+jest.setTimeout(60000);
 describe('Github tests', () => {
   const OLD_ENV = process.env;
 

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -225,19 +225,19 @@ class Github {
     const { actions } = octokit(this.token, this.repo);
     let runners = [];
 
-    if (typeof repo !== 'undefined') {
+    if (typeof repo === 'undefined') {
       ({
         data: { runners }
-      } = await actions.listSelfHostedRunnersForRepo({
-        owner,
-        repo,
+      } = await actions.listSelfHostedRunnersForOrg({
+        org: owner,
         per_page: 100
       }));
     } else {
       ({
         data: { runners }
-      } = await actions.listSelfHostedRunnersForOrg({
-        org: owner,
+      } = await actions.listSelfHostedRunnersForRepo({
+        owner,
+        repo,
         per_page: 100
       }));
     }

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -248,7 +248,7 @@ class Github {
   async runnerByName(opts = {}) {
     const { name } = opts;
     const runners = await this.getRunners(opts);
-    const runner = runners.filter((runner) => runner.name === name)[0];
+    const runner = runners.find((runner) => runner.name === name);
     if (runner) return { id: runner.id, name: runner.name, busy: runner.busy, online: runner.status === 'online' };
   }
 

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -249,7 +249,13 @@ class Github {
     const { name } = opts;
     const runners = await this.getRunners(opts);
     const runner = runners.find((runner) => runner.name === name);
-    if (runner) return { id: runner.id, name: runner.name, busy: runner.busy, online: runner.status === 'online' };
+    if (runner)
+      return {
+        id: runner.id,
+        name: runner.name,
+        busy: runner.busy,
+        online: runner.status === 'online'
+      };
   }
 
   async runnersByLabels(opts = {}) {
@@ -263,7 +269,12 @@ class Github {
             runner.labels.map(({ name }) => name).includes(label)
           )
       )
-      .map((runner) => ({ id: runner.id, name: runner.name, busy: runner.busy, online: runner.status === 'online' }));
+      .map((runner) => ({
+        id: runner.id,
+        name: runner.name,
+        busy: runner.busy,
+        online: runner.status === 'online'
+      }));
   }
 
   async prCreate(opts = {}) {

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -249,7 +249,7 @@ class Github {
     const { name } = opts;
     const runners = await this.getRunners(opts);
     const runner = runners.filter((runner) => runner.name === name)[0];
-    if (runner) return { id: runner.id, name: runner.name };
+    if (runner) return { id: runner.id, name: runner.name, busy: runner.busy, online: runner.status === 'online' };
   }
 
   async runnersByLabels(opts = {}) {
@@ -263,7 +263,7 @@ class Github {
             runner.labels.map(({ name }) => name).includes(label)
           )
       )
-      .map((runner) => ({ id: runner.id, name: runner.name }));
+      .map((runner) => ({ id: runner.id, name: runner.name, busy: runner.busy, online: runner.status === 'online' }));
   }
 
   async prCreate(opts = {}) {

--- a/src/drivers/gitlab.js
+++ b/src/drivers/gitlab.js
@@ -185,14 +185,14 @@ class Gitlab {
       (runner) => runner.name === name || runner.description === name
     )[0];
 
-    if (runner) return { id: runner.id, name: runner.name };
+    if (runner) return { id: runner.id, name: runner.name, busy: runner.active, online: runner.status === 'online' };
   }
 
   async runnersByLabels(opts = {}) {
     const { labels } = opts;
     const endpoint = `/runners?per_page=100?tag_list=${labels}`;
     const runners = await this.request({ endpoint, method: 'GET' });
-    return runners.map((runner) => ({ id: runner.id, name: runner.name }));
+    return runners.map((runner) => ({ id: runner.id, name: runner.name, busy: runner.active, online: runner.status === 'online' }));
   }
 
   async prCreate(opts = {}) {

--- a/src/drivers/gitlab.js
+++ b/src/drivers/gitlab.js
@@ -185,14 +185,25 @@ class Gitlab {
       (runner) => runner.name === name || runner.description === name
     );
 
-    if (runner) return { id: runner.id, name: runner.name, busy: runner.active, online: runner.status === 'online' };
+    if (runner)
+      return {
+        id: runner.id,
+        name: runner.name,
+        busy: runner.active,
+        online: runner.status === 'online'
+      };
   }
 
   async runnersByLabels(opts = {}) {
     const { labels } = opts;
     const endpoint = `/runners?per_page=100?tag_list=${labels}`;
     const runners = await this.request({ endpoint, method: 'GET' });
-    return runners.map((runner) => ({ id: runner.id, name: runner.name, busy: runner.active, online: runner.status === 'online' }));
+    return runners.map((runner) => ({
+      id: runner.id,
+      name: runner.name,
+      busy: runner.active,
+      online: runner.status === 'online'
+    }));
   }
 
   async prCreate(opts = {}) {

--- a/src/drivers/gitlab.js
+++ b/src/drivers/gitlab.js
@@ -181,9 +181,9 @@ class Gitlab {
 
     const endpoint = `/runners?per_page=100`;
     const runners = await this.request({ endpoint, method: 'GET' });
-    const runner = runners.filter(
+    const runner = runners.find(
       (runner) => runner.name === name || runner.description === name
-    )[0];
+    );
 
     if (runner) return { id: runner.id, name: runner.name, busy: runner.active, online: runner.status === 'online' };
   }

--- a/src/drivers/gitlab.js
+++ b/src/drivers/gitlab.js
@@ -182,7 +182,7 @@ class Gitlab {
     return await Promise.all(
       runners.map(async ({ id, name, description, active, online }) => ({
         id,
-        name: name || description,
+        name: description,
         labels: (
           await this.request({ endpoint: `/runners/${id}`, method: 'GET' })
         ).tag_list,


### PR DESCRIPTION
The `--reuse` option should not consider offline runners as reusable.