### PR TITLE
Fix inconsistencies between local and remote formatters

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,10 +4,7 @@ module.exports = {
     commonjs: true,
     es6: true
   },
-  extends: [
-    'standard',
-    'prettier'
-  ],
+  extends: ['standard', 'prettier'],
   globals: {
     Atomics: 'readonly',
     SharedArrayBuffer: 'readonly'
@@ -15,15 +12,13 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 2018
   },
-  ignorePatterns: ['assets/',  'dist/', 'node_modules/'],
+  ignorePatterns: ['assets/', 'dist/', 'node_modules/'],
   rules: {
-    'camelcase': [1, {'properties': 'never'}],
+    camelcase: [1, { properties: 'never' }],
     'prettier/prettier': 'error'
   },
-  plugins: [
-    'prettier'
-  ],
+  plugins: ['prettier'],
   env: {
     jest: true
   }
-}
+};

--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -1,8 +1,4 @@
 restylers:
   - name: prettier
     arguments: ['--write']
-    include:
-      - 'src/**/*.js'
-      - 'bin/**/*.js'
-      - 'assets/*.json'
-      - './**/*.{yaml,yml,md,json}'
+    include: ['**/*.{js,md,yaml,yml,json}']

--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -1,4 +1,4 @@
 restylers:
   - name: prettier
     arguments: ['--write']
-    include: ['**/*.{js,md,yaml,yml,json}']
+    include: ['**/*.{js,json,md,yaml,yml}']

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "cml-pr": "bin/cml-pr.js"
   },
   "scripts": {
-    "lintfix": "eslint --fix ./",
+    "lintfix": "eslint --fix ./ && prettier --write '**/*.{js,json,md,yaml,yml}'",
     "lint": "eslint ./",
     "test": "jest --passWithNoTests",
     "do_snapshots": "jest --updateSnapshot"
@@ -54,7 +54,7 @@
       "eslint --fix",
       "prettier --write"
     ],
-    "*.{md,yaml,yml,json}": [
+    "*.{json,md,yaml,yml}": [
       "prettier --write"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -51,9 +51,10 @@
   },
   "lint-staged": {
     "*.js": [
-      "eslint --fix"
+      "eslint --fix",
+      "prettier --write"
     ],
-    "*.{md,yaml,yml}": [
+    "*.{md,yaml,yml,json}": [
       "prettier --write"
     ]
   },


### PR DESCRIPTION
## Local formattter configuration

We use [`husky`](https://www.npmjs.com/package/husky) to configure pre-commit hooks so files are automatically linted and formatted with [`lint-staged`](https://www.npmjs.com/package/lint-staged) on each commit. Unfortunately, `prettier` is not being used for files with the `js` extension due to a misconfiguration.

https://github.com/iterative/cml/blob/1ed743d7641c248afaf00ece224bef19ebeb9174/package.json#L47-L51

https://github.com/iterative/cml/blob/1ed743d7641c248afaf00ece224bef19ebeb9174/package.json#L52-L59

## Remote formattter configuration

Here we use `prettier` for all the extensions above plus the `js` and `json` ones. That's the issue behind #623 and company.
https://github.com/iterative/cml/blob/1ed743d7641c248afaf00ece224bef19ebeb9174/.restyled.yaml#L1-L8