### PR TITLE
Remove debug triggers from gitlab.yml

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -1,8 +1,5 @@
 name: GitLab
-on:
-  workflow_dispatch:
-  pull_request:
-  push:
+on: pull_request
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `pull` trigger was creating redundant runs.