### PR TITLE
Update containers' latest tag and add the docker.io/iterativeai registry

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -122,7 +122,7 @@ jobs:
             for registry in docker.io/{dvcorg,iterativeai} ghcr.io/iterative; do
               [[ "${{ matrix.latest }}" == "true" ]] && echo "$registry/cml:latest"
               echo "$registry/cml:$tag"
-            done
+            done | sed 's/\n/%0A/g'
           )"
       - uses: docker/setup-buildx-action@v1
       - uses: actions/cache@v2

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -82,6 +82,9 @@ jobs:
             python: 3.8
             cuda: 11.0.3
             cudnn: 8
+          - latest: true  # update the values below after introducing a new major version
+            base: 1
+            dvc: 2
     steps:
       - uses: actions/checkout@v2
         with:
@@ -109,11 +112,18 @@ jobs:
           echo ::set-output name=cml_version::$cml_version
           if [[ ${{ matrix.gpu }} == true ]]; then
             echo ::set-output name=base::nvidia/cuda:${{ matrix.cuda }}-cudnn${{ matrix.cudnn }}-runtime-ubuntu${{ matrix.ubuntu }}
-            echo ::set-output name=tag::${cml_version//.*/}-dvc${{ matrix.dvc }}-base${{ matrix.base }}-gpu
+            tag="${cml_version//.*/}-dvc${{ matrix.dvc }}-base${{ matrix.base }}-gpu"
           else
             echo ::set-output name=base::ubuntu:${{ matrix.ubuntu }}
-            echo ::set-output name=tag::${cml_version//.*/}-dvc${{ matrix.dvc }}-base${{ matrix.base }}
+            tag="${cml_version//.*/}-dvc${{ matrix.dvc }}-base${{ matrix.base }}"
           fi
+          
+          echo ::set-output name=tag::"$(
+            for registry in docker.io/{dvcorg,iterativeai} ghcr.io/iterative; do
+              [[ "${{ matrix.latest }}" == "true" ]] && echo "$registry/cml:latest"
+              echo "$registry/cml:$tag"
+            done
+          )"
       - uses: docker/setup-buildx-action@v1
       - uses: actions/cache@v2
         with:
@@ -140,10 +150,7 @@ jobs:
             'schedule' }}
           context: ./
           file: ./Dockerfile
-          tags: |
-            docker.io/dvcorg/cml:${{ steps.metadata.outputs.tag }}
-            docker.io/iterativeai/cml:${{ steps.metadata.outputs.tag }}
-            ghcr.io/iterative/cml:${{ steps.metadata.outputs.tag }}
+          tags: ${{ steps.metadata.outputs.tags }}
           build-args: |
             CML_VERSION=${{ steps.metadata.outputs.cml_version }}
             DVC_VERSION=${{ matrix.dvc }}

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -142,6 +142,7 @@ jobs:
           file: ./Dockerfile
           tags: |
             docker.io/dvcorg/cml:${{ steps.metadata.outputs.tag }}
+            docker.io/iterativeai/cml:${{ steps.metadata.outputs.tag }}
             ghcr.io/iterative/cml:${{ steps.metadata.outputs.tag }}
           build-args: |
             CML_VERSION=${{ steps.metadata.outputs.cml_version }}

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -82,7 +82,7 @@ jobs:
             python: 3.8
             cuda: 11.0.3
             cudnn: 8
-          - latest: true  # update the values below after introducing a new major version
+          - latest: true # update the values below after introducing a new major version
             base: 1
             dvc: 2
     steps:
@@ -110,19 +110,19 @@ jobs:
           )')
           echo ::set-output name=cache_tag::${cml_version}-${dvc_version}-${{ matrix.base }}-${{ matrix.gpu }}
           echo ::set-output name=cml_version::$cml_version
+          tag=${cml_version//.*/}-dvc${{ matrix.dvc }}-base${{ matrix.base }}
           if [[ ${{ matrix.gpu }} == true ]]; then
             echo ::set-output name=base::nvidia/cuda:${{ matrix.cuda }}-cudnn${{ matrix.cudnn }}-runtime-ubuntu${{ matrix.ubuntu }}
-            tag="${cml_version//.*/}-dvc${{ matrix.dvc }}-base${{ matrix.base }}-gpu"
+            tag=${tag}-gpu
           else
             echo ::set-output name=base::ubuntu:${{ matrix.ubuntu }}
-            tag="${cml_version//.*/}-dvc${{ matrix.dvc }}-base${{ matrix.base }}"
           fi
-          
-          echo ::set-output name=tag::"$(
+
+          echo ::set-output name=tags::"$(
             for registry in docker.io/{dvcorg,iterativeai} ghcr.io/iterative; do
-              [[ "${{ matrix.latest }}" == "true" ]] && echo "$registry/cml:latest"
-              echo "$registry/cml:$tag"
-            done | sed 's/\n/%0A/g'
+              [[ "${{ matrix.latest }}" == "true" ]] && echo "${registry}/cml:latest"
+              echo "${registry}/cml:${tag}"
+            done | tr '\n' ',' | head -c-1
           )"
       - uses: docker/setup-buildx-action@v1
       - uses: actions/cache@v2


### PR DESCRIPTION
### From https://github.com/iterative/cml/issues/383#issuecomment-870834591

- [x] Make `latest` point to `0-dvc2-base1-gpu` or whatever the latest tag is
- [x] Push active tags to `@iterativeai/cml` and soft-deprecate `@dvcorg/cml`
- [x] Check credentials — ideally one bot user with push access to both organizations [#infrastructure➔1625237297087600](https://iterativeai.slack.com/archives/C01R00PPQ1L/p1625237297087600)