### PR TITLE
Fix latest GPU container image tags

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -120,7 +120,13 @@ jobs:
 
           echo ::set-output name=tags::"$(
             for registry in docker.io/{dvcorg,iterativeai} ghcr.io/iterative; do
-              [[ "${{ matrix.latest }}" == "true" ]] && echo "${registry}/cml:latest"
+              if [[ "${{ matrix.latest }}" == "true" ]]; then
+                if [[ "${{ matrix.gpu }}" == "true" ]]; then
+                  echo "${registry}/cml:latest-gpu"
+                else
+                  echo "${registry}/cml:latest"
+                fi
+              fi
               echo "${registry}/cml:${tag}"
             done | tr '\n' ',' | head -c-1
           )"

--- a/src/drivers/gitlab.js
+++ b/src/drivers/gitlab.js
@@ -140,7 +140,11 @@ class Gitlab {
     try {
       await exec('nvidia-smi');
     } catch (err) {
-      gpu = false;
+      try {
+        await exec('cuda-smi');
+      } catch (err) {
+        gpu = false;
+      }
     }
 
     try {

--- a/src/drivers/gitlab.js
+++ b/src/drivers/gitlab.js
@@ -162,7 +162,7 @@ class Gitlab {
         --token "${token}" \
         --wait-timeout ${idleTimeout} \
         --executor "${IN_DOCKER ? 'shell' : 'docker'}" \
-        --docker-image "dvcorg/cml:latest" \
+        --docker-image "iterativeai/cml:${gpu ? 'latest-gpu' : 'latest'}" \
         --docker-runtime "${gpu ? 'nvidia' : ''}" \
         ${single ? '--max-builds 1' : ''}`;
 


### PR DESCRIPTION
We were pushing the `latest` tag twice<sup>[[1](https://github.com/iterative/cml/runs/3133036634?check_suite_focus=true#step:8:103), [2](https://github.com/iterative/cml/runs/3133036580?check_suite_focus=true#step:8:103)]</sup> with the latest GPU and non-GPU images, in parallel. Whichever image got pushed first ended up overriding the other one. 🙈 

 - Closes #666 . Baremetal will check nvidia-smi and determine gpu and use the proper image