### PR TITLE
GH runner auto update

### DIFF
--- a/bin/cml-runner.js
+++ b/bin/cml-runner.js
@@ -41,7 +41,7 @@ const shutdown = async (opts) => {
   RUNNER_SHUTTING_DOWN = true;
 
   const { error, cloud } = opts;
-  const { name, workdir = '', tfResource, noRetry } = opts;
+  const { name, workdir = '', tfResource, noRetry, why } = opts;
   const tfPath = workdir;
 
   const unregisterRunner = async () => {
@@ -95,10 +95,14 @@ const shutdown = async (opts) => {
     }
   };
 
+  if (error) console.log(error);
   console.log(
-    JSON.stringify({ level: error ? 'error' : 'info', status: 'terminated' })
+    JSON.stringify({
+      level: error ? 'error' : 'info',
+      status: 'terminated',
+      why
+    })
   );
-  if (error) console.error(error);
   await sleep(RUNNER_DESTROY_DELAY);
 
   if (cloud) {
@@ -273,14 +277,18 @@ const runLocal = async (opts) => {
 
   proc.stderr.on('data', dataHandler);
   proc.stdout.on('data', dataHandler);
-  proc.on('uncaughtException', () => shutdown(opts));
-  proc.on('disconnect', () => shutdown(opts));
-  proc.on('exit', () => shutdown(opts));
+  proc.on('uncaughtException', () =>
+    shutdown({ ...opts, why: 'proc_uncaughtException' })
+  );
+  proc.on('disconnect', () => shutdown({ ...opts, why: 'proc_disconnect' }));
+  proc.on('exit', () => shutdown({ ...opts, why: 'proc_exit' }));
 
   if (!noRetry) {
     try {
       console.log(`EC2 id ${await SpotNotifier.instanceId()}`);
-      SpotNotifier.on('termination', () => shutdown(opts));
+      SpotNotifier.on('termination', () =>
+        shutdown({ ...opts, why: 'spot_termination' })
+      );
       SpotNotifier.start();
     } catch (err) {
       console.log('SpotNotifier can not be started.');
@@ -290,7 +298,7 @@ const runLocal = async (opts) => {
   if (parseInt(idleTimeout) !== 0) {
     const watcher = setInterval(() => {
       RUNNER_TIMEOUT_TIMER > idleTimeout &&
-        shutdown(opts) &&
+        shutdown({ ...opts, why: 'timeout' }) &&
         clearInterval(watcher);
 
       if (!RUNNER_JOBS_RUNNING.length) RUNNER_TIMEOUT_TIMER++;
@@ -304,7 +312,7 @@ const runLocal = async (opts) => {
           new Date().getTime() - new Date(job.date).getTime() >
           GH_5_MIN_TIMEOUT
         )
-          shutdown(opts) && clearInterval(watcher);
+          shutdown({ ...opts, why: '72timeout' }) && clearInterval(watcher);
       });
     }, 60 * 1000);
   }
@@ -313,9 +321,9 @@ const runLocal = async (opts) => {
 };
 
 const run = async (opts) => {
-  process.on('SIGTERM', () => shutdown(opts));
-  process.on('SIGINT', () => shutdown(opts));
-  process.on('SIGQUIT', () => shutdown(opts));
+  process.on('SIGTERM', () => shutdown({ ...opts, why: 'SIGTERM' }));
+  process.on('SIGINT', () => shutdown({ ...opts, why: 'SIGINT' }));
+  process.on('SIGQUIT', () => shutdown({ ...opts, why: 'SIGQUIT' }));
 
   opts.workdir = RUNNER_PATH;
   const {

--- a/bin/cml-runner.js
+++ b/bin/cml-runner.js
@@ -312,7 +312,8 @@ const runLocal = async (opts) => {
           new Date().getTime() - new Date(job.date).getTime() >
           GH_5_MIN_TIMEOUT
         )
-          shutdown({ ...opts, reason: `timeout:72` }) && clearInterval(watcher);
+          shutdown({ ...opts, reason: 'timeout:72h' }) &&
+            clearInterval(watcher);
       });
     }, 60 * 1000);
   }

--- a/bin/cml-runner.js
+++ b/bin/cml-runner.js
@@ -298,7 +298,7 @@ const runLocal = async (opts) => {
   if (parseInt(idleTimeout) !== 0) {
     const watcher = setInterval(() => {
       RUNNER_TIMEOUT_TIMER > idleTimeout &&
-        shutdown({ ...opts, reason: 'timeout' }) &&
+        shutdown({ ...opts, reason: `timeout:${idleTimeout}` }) &&
         clearInterval(watcher);
 
       if (!RUNNER_JOBS_RUNNING.length) RUNNER_TIMEOUT_TIMER++;

--- a/bin/cml-runner.js
+++ b/bin/cml-runner.js
@@ -281,7 +281,7 @@ const runLocal = async (opts) => {
     shutdown({ ...opts, why: 'proc_uncaughtException' })
   );
   proc.on('disconnect', () => shutdown({ ...opts, why: 'proc_disconnect' }));
-  proc.on('exit', () => shutdown({ ...opts, why: 'proc_exit' }));
+  // proc.on('exit', () => shutdown({ ...opts, why: 'proc_exit' }));
 
   if (!noRetry) {
     try {

--- a/bin/cml-runner.js
+++ b/bin/cml-runner.js
@@ -312,7 +312,7 @@ const runLocal = async (opts) => {
           new Date().getTime() - new Date(job.date).getTime() >
           GH_5_MIN_TIMEOUT
         )
-          shutdown({ ...opts, reason: '72timeout' }) && clearInterval(watcher);
+          shutdown({ ...opts, reason: `timeout:72` }) && clearInterval(watcher);
       });
     }, 60 * 1000);
   }

--- a/src/cml.js
+++ b/src/cml.js
@@ -155,7 +155,6 @@ class CML {
 
     try {
       data = data.toString('utf8');
-      // console.log(data);
 
       let log = {
         level: 'info',

--- a/src/cml.js
+++ b/src/cml.js
@@ -155,7 +155,7 @@ class CML {
 
     try {
       data = data.toString('utf8');
-      console.log(data);
+      // console.log(data);
 
       let log = {
         level: 'info',
@@ -179,7 +179,9 @@ class CML {
         } else if (data.includes('Listening for Jobs')) {
           log.status = 'ready';
         }
-        return log;
+
+        const [, message] = data.split(/[A-Z]:\s/);
+        return { ...log, message: (message || data).replace(/\n/g, '') };
       }
 
       if (this.driver === GITLAB) {

--- a/src/cml.js
+++ b/src/cml.js
@@ -155,6 +155,7 @@ class CML {
 
     try {
       data = data.toString('utf8');
+      console.log(data);
 
       let log = {
         level: 'info',

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -208,13 +208,15 @@ class Github {
         await fs.unlink(runnerCfg);
       } catch (e) {
         const arch = process.platform === 'darwin' ? 'osx-x64' : 'linux-x64';
-        const { tag_name: ver } = (
+        const { tag_name: ver } = await (
           await fetch(
             'https://api.github.com/repos/actions/runner/releases/latest'
           )
         ).json();
         const destination = resolve(workdir, 'actions-runner.tar.gz');
-        const url = `https://github.com/actions/runner/releases/download/v${ver}/actions-runner-${arch}-${ver}.tar.gz`;
+        const url = `https://github.com/actions/runner/releases/download/${ver}/actions-runner-${arch}-${ver.substring(
+          1
+        )}.tar.gz`;
         await download({ url, path: destination });
         await tar.extract({ file: destination, cwd: workdir });
         await exec(`chmod -R 777 ${workdir}`);

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -2,6 +2,7 @@ const url = require('url');
 const { spawn } = require('child_process');
 const { resolve } = require('path');
 const fs = require('fs').promises;
+const fetch = require('node-fetch');
 
 const github = require('@actions/github');
 const { Octokit } = require('@octokit/rest');
@@ -207,7 +208,11 @@ class Github {
         await fs.unlink(runnerCfg);
       } catch (e) {
         const arch = process.platform === 'darwin' ? 'osx-x64' : 'linux-x64';
-        const ver = 'v2.279.0';
+        const { tag_name: ver } = (
+          await fetch(
+            'https://api.github.com/repos/actions/runner/releases/latest'
+          )
+        ).json();
         const destination = resolve(workdir, 'actions-runner.tar.gz');
         const url = `https://github.com/actions/runner/releases/download/v${ver}/actions-runner-${arch}-${ver}.tar.gz`;
         await download({ url, path: destination });

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -226,7 +226,7 @@ class Github {
         `${resolve(
           workdir,
           'config.sh'
-        )} --token "${await this.runnerToken()}" --url "${
+        )} --unattended  --token "${await this.runnerToken()}" --url "${
           this.repo
         }"  --name "${name}" --labels "${labels}" --work "${resolve(
           workdir,

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -207,7 +207,7 @@ class Github {
         await fs.unlink(runnerCfg);
       } catch (e) {
         const arch = process.platform === 'darwin' ? 'osx-x64' : 'linux-x64';
-        const ver = '2.278.0';
+        const ver = 'v2.279.0';
         const destination = resolve(workdir, 'actions-runner.tar.gz');
         const url = `https://github.com/actions/runner/releases/download/v${ver}/actions-runner-${arch}-${ver}.tar.gz`;
         await download({ url, path: destination });


### PR DESCRIPTION
New GH runners restarts after update and we destroy them if they exit the CML wrapper. To avoid that we are always downloading latest.

 - closes #676 
 - adds reason of termination in logs
 - adds GH message logs