### PR TITLE
Add missing backslash on container ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,5 +105,5 @@ ENV IN_DOCKER=1
 # also works for GitLab CI/CD
 # https://gitlab.com/gitlab-org/gitlab-runner/-/blob/4c42e96/shells/bash.go#L18-37
 # https://gitlab.com/gitlab-org/gitlab-runner/-/blob/4c42e96/shells/bash.go#L288
-ENTRYPOINT ["/bin/bash", "-c", "echo \"$0\" | grep -qE '^(pr|publish|runner|send-(comment|github-check)|tensorboard-dev|--?\w.*)$' && exec cml \"$0\" \"$@\" || exec \"$0\" \"$@\""]
+ENTRYPOINT ["/bin/bash", "-c", "echo \"$0\" | grep -qE '^(pr|publish|runner|send-(comment|github-check)|tensorboard-dev|--?\\w.*)$' && exec cml \"$0\" \"$@\" || exec \"$0\" \"$@\""]
 CMD ["--help"]


### PR DESCRIPTION
Silly mistake that I missed when reviewing #716: if [`ENTRYPOINT`](https://docs.docker.com/engine/reference/builder/#entrypoint) doesn't contain a valid JSON array, it's going to be interpreted as a shell command, producing errors like the following:

```
sh: [/bin/bash,: No such file or directory
```

It's breaking all our [GitLab tests](https://gitlab.com/iterative.ai/cml/-/jobs/1609576824), but it should not, as CML has not been released since July 28th. 🤔  Has somebody manually deployed our container images lately?