### PR TITLE
Retry pipe EAGAIN on macOS

### DIFF
--- a/src/pipe-args.js
+++ b/src/pipe-args.js
@@ -25,7 +25,13 @@ module.exports.load = (format) => {
       chunks.push(buffer.slice(0, nbytes));
     } catch (err) {
       if (err.code === 'EOF') break; // HACK: see nodejs/node#35997
-      if (err.code === 'EAGAIN') break;
+      if (err.code === 'EAGAIN') {
+        if (process.platform === 'darwin') {
+          continue;
+        } else {
+          break;
+        }
+      }
       throw err;
     }
   }


### PR DESCRIPTION
E... AGAIN, [blame](https://github.com/iterative/cml/blame/0e9a2d0b6e6fdae67f1b954cb5eee875b62e6080/src/pipe-args.js#L28) on me, from the last bullet point on #703; I fixed an edge case just to break another one.

We should **really** get rid of `pipe-args.js` and use something more or less standard like [`get-stdin`](https://www.npmjs.com/package/get-stdin) as hinted in https://github.com/iterative/cml/pull/67#discussion_r415530205.

Maintaining yet another cross–platform pipe support library on our own doesn't look like a great idea.