### PR TITLE
Include full stack traces on Winston JSONL logs

### DIFF
--- a/bin/cml.js
+++ b/bin/cml.js
@@ -14,7 +14,10 @@ const configureLogger = (level) => {
           winston.format.colorize({ all: true }),
           winston.format.simple()
         )
-      : winston.format.json(),
+      : winston.format.combine(
+          winston.format.errors({ stack: true }),
+          winston.format.json()
+        ),
     transports: [
       new winston.transports.Console({
         handleExceptions: true,


### PR DESCRIPTION
#### Before

```
{"level":"error"}
```

#### After

```json
{"level":"error","message":"terraform version\n\t\n\t/bin/sh: 1: terraform: not found\n","stack":"Error: terraform version\n\t\n\t/bin/sh: 1: terraform: not found\n\n    at /workspaces/cml/src/utils.js:15:27\n    at ChildProcess.exithandler (child_process.js:397:5)\n    at ChildProcess.emit (events.js:400:28)\n    at maybeClose (internal/child_process.js:1055:16)\n    at Socket.<anonymous> (internal/child_process.js:441:11)\n    at Socket.emit (events.js:400:28)\n    at Pipe.<anonymous> (net.js:675:12)"}
```