### PR TITLE
Update dependencies and fix merge mistake

### DIFF
--- a/bin/cml/runner.js
+++ b/bin/cml/runner.js
@@ -89,8 +89,8 @@ const shutdown = async (opts) => {
     winston.info('runner status', { reason, status: 'terminated' });
   }
 
-  winston.info(`waiting ${RUNNER_DESTROY_DELAY} seconds before exiting...`);
-  await sleep(RUNNER_DESTROY_DELAY);
+  winston.info(`waiting ${destroyDelay} seconds before exiting...`);
+  await sleep(destroyDelay);
 
   if (cloud) {
     await destroyTerraform();

--- a/bin/cml/tensorboard-dev.test.js
+++ b/bin/cml/tensorboard-dev.test.js
@@ -67,7 +67,7 @@ Options:
   -c, --credentials   TB credentials as json. Usually found at
                       ~/.config/tensorboard/credentials/uploader-creds.json. If
                       not specified will look for the json at the env variable
-                      TB_CREDENTIALS.                                   [string]
+                      TB_CREDENTIALS.                        [string] [required]
       --logdir        Directory containing the logs to process.         [string]
       --name          Tensorboard experiment title. Max 100 characters. [string]
       --description   Tensorboard experiment description. Markdown format. Max

--- a/package-lock.json
+++ b/package-lock.json
@@ -1052,24 +1052,45 @@
       }
     },
     "@octokit/auth-token": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.2.tgz",
-      "integrity": "sha512-jE/lE/IKIz2v1+/P0u4fJqv0kYwXOTujKemJMFr6FeopsxlIK3+wKDCJGnysg81XID5TgZQbIfuJ5J0lnTiuyQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
+      "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
       "requires": {
-        "@octokit/types": "^5.0.0"
+        "@octokit/types": "^6.0.3"
+      },
+      "dependencies": {
+        "@octokit/types": {
+          "version": "6.31.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.31.0.tgz",
+          "integrity": "sha512-xobpvYmMYoFSxZB6jL1TPTMMZkxZIBlY145ZKibBJDKCczP1FrLLougtuVOZywGVZdcYs8oq2Bxb3aMjqIFeiw==",
+          "requires": {
+            "@octokit/openapi-types": "^10.5.0"
+          }
+        }
       }
     },
     "@octokit/core": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.1.2.tgz",
-      "integrity": "sha512-AInOFULmwOa7+NFi9F8DlDkm5qtZVmDQayi7TUgChE3yeIGPq0Y+6cAEXPexQ3Ea+uZy66hKEazR7DJyU+4wfw==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.5.1.tgz",
+      "integrity": "sha512-omncwpLVxMP+GLpLPgeGJBF6IWJFjXDS5flY5VbppePYX9XehevbDykRH9PdCdvqt9TS5AOTiDide7h0qrkHjw==",
       "requires": {
-        "@octokit/auth-token": "^2.4.0",
-        "@octokit/graphql": "^4.3.1",
-        "@octokit/request": "^5.4.0",
-        "@octokit/types": "^5.0.0",
-        "before-after-hook": "^2.1.0",
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.6.0",
+        "@octokit/request-error": "^2.0.5",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.2.0",
         "universal-user-agent": "^6.0.0"
+      },
+      "dependencies": {
+        "@octokit/types": {
+          "version": "6.31.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.31.0.tgz",
+          "integrity": "sha512-xobpvYmMYoFSxZB6jL1TPTMMZkxZIBlY145ZKibBJDKCczP1FrLLougtuVOZywGVZdcYs8oq2Bxb3aMjqIFeiw==",
+          "requires": {
+            "@octokit/openapi-types": "^10.5.0"
+          }
+        }
       }
     },
     "@octokit/endpoint": {
@@ -1083,19 +1104,29 @@
       }
     },
     "@octokit/graphql": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.4.tgz",
-      "integrity": "sha512-ITpZ+dQc0cXAW1FmDkHJJM+8Lb6anUnin0VB5hLBilnYVdLC0ICFU/KIvT7OXfW9S81DE3U4Vx2EypDG1OYaPA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
+      "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
       "requires": {
-        "@octokit/request": "^5.3.0",
-        "@octokit/types": "^5.0.0",
+        "@octokit/request": "^5.6.0",
+        "@octokit/types": "^6.0.3",
         "universal-user-agent": "^6.0.0"
+      },
+      "dependencies": {
+        "@octokit/types": {
+          "version": "6.31.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.31.0.tgz",
+          "integrity": "sha512-xobpvYmMYoFSxZB6jL1TPTMMZkxZIBlY145ZKibBJDKCczP1FrLLougtuVOZywGVZdcYs8oq2Bxb3aMjqIFeiw==",
+          "requires": {
+            "@octokit/openapi-types": "^10.5.0"
+          }
+        }
       }
     },
     "@octokit/openapi-types": {
-      "version": "10.1.4",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-10.1.4.tgz",
-      "integrity": "sha512-poafDt5Ac5GV86baVXDdj6xeIMrEVEuRweMwkZfoXwySYWA0eKgrOP/ZaDE7V/hlW32z6oO61Zy/5U2oSZlDWw=="
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-10.5.0.tgz",
+      "integrity": "sha512-yt8GpYL0s1bLZR7602l0Im5zfmB3UdHYCfcrv3ZGRX95BjX66UQeH4asXjXo8xBit9HneCctVhTMN0On/duukQ=="
     },
     "@octokit/plugin-paginate-rest": {
       "version": "2.3.2",
@@ -1129,145 +1160,98 @@
       },
       "dependencies": {
         "@octokit/types": {
-          "version": "6.27.1",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.27.1.tgz",
-          "integrity": "sha512-p8VR2OTO1ozxqdAvPeCDDMNmcBzkOL6sPogy2MaEQCapbeWcWNDbwZnqMT3VTZ0DLBBAO0PyHYzU8bA99zd1Fg==",
+          "version": "6.31.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.31.0.tgz",
+          "integrity": "sha512-xobpvYmMYoFSxZB6jL1TPTMMZkxZIBlY145ZKibBJDKCczP1FrLLougtuVOZywGVZdcYs8oq2Bxb3aMjqIFeiw==",
           "requires": {
-            "@octokit/openapi-types": "^10.1.4"
+            "@octokit/openapi-types": "^10.5.0"
           }
         }
       }
     },
     "@octokit/request": {
-      "version": "5.4.7",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.7.tgz",
-      "integrity": "sha512-FN22xUDP0i0uF38YMbOfx6TotpcENP5W8yJM1e/LieGXn6IoRxDMnBf7tx5RKSW4xuUZ/1P04NFZy5iY3Rax1A==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.1.tgz",
+      "integrity": "sha512-Ls2cfs1OfXaOKzkcxnqw5MR6drMA/zWX/LIS/p8Yjdz7QKTPQLMsB3R+OvoxE6XnXeXEE2X7xe4G4l4X0gRiKQ==",
       "requires": {
         "@octokit/endpoint": "^6.0.1",
-        "@octokit/request-error": "^2.0.0",
-        "@octokit/types": "^5.0.0",
-        "deprecation": "^2.0.0",
-        "is-plain-object": "^4.0.0",
-        "node-fetch": "^2.3.0",
-        "once": "^1.4.0",
+        "@octokit/request-error": "^2.1.0",
+        "@octokit/types": "^6.16.1",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.1",
         "universal-user-agent": "^6.0.0"
-      }
-    },
-    "@octokit/request-error": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.2.tgz",
-      "integrity": "sha512-2BrmnvVSV1MXQvEkrb9zwzP0wXFNbPJij922kYBTLIlIafukrGOb+ABBT2+c6wZiuyWDH1K1zmjGQ0toN/wMWw==",
-      "requires": {
-        "@octokit/types": "^5.0.1",
-        "deprecation": "^2.0.0",
-        "once": "^1.4.0"
-      }
-    },
-    "@octokit/rest": {
-      "version": "18.10.0",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.10.0.tgz",
-      "integrity": "sha512-esHR5OKy38bccL/sajHqZudZCvmv4yjovMJzyXlphaUo7xykmtOdILGJ3aAm0mFHmMLmPFmDMJXf39cAjNJsrw==",
-      "requires": {
-        "@octokit/core": "^3.5.1",
-        "@octokit/plugin-paginate-rest": "^2.16.0",
-        "@octokit/plugin-request-log": "^1.0.4",
-        "@octokit/plugin-rest-endpoint-methods": "^5.9.0"
       },
       "dependencies": {
-        "@octokit/auth-token": {
-          "version": "2.4.5",
-          "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.5.tgz",
-          "integrity": "sha512-BpGYsPgJt05M7/L/5FoE1PiAbdxXFZkX/3kDYcsvd1v6UhlnE5e96dTDr0ezX/EFwciQxf3cNV0loipsURU+WA==",
-          "requires": {
-            "@octokit/types": "^6.0.3"
-          }
-        },
-        "@octokit/core": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.5.1.tgz",
-          "integrity": "sha512-omncwpLVxMP+GLpLPgeGJBF6IWJFjXDS5flY5VbppePYX9XehevbDykRH9PdCdvqt9TS5AOTiDide7h0qrkHjw==",
-          "requires": {
-            "@octokit/auth-token": "^2.4.4",
-            "@octokit/graphql": "^4.5.8",
-            "@octokit/request": "^5.6.0",
-            "@octokit/request-error": "^2.0.5",
-            "@octokit/types": "^6.0.3",
-            "before-after-hook": "^2.2.0",
-            "universal-user-agent": "^6.0.0"
-          }
-        },
-        "@octokit/graphql": {
-          "version": "4.8.0",
-          "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
-          "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
-          "requires": {
-            "@octokit/request": "^5.6.0",
-            "@octokit/types": "^6.0.3",
-            "universal-user-agent": "^6.0.0"
-          }
-        },
-        "@octokit/openapi-types": {
-          "version": "10.1.4",
-          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-10.1.4.tgz",
-          "integrity": "sha512-poafDt5Ac5GV86baVXDdj6xeIMrEVEuRweMwkZfoXwySYWA0eKgrOP/ZaDE7V/hlW32z6oO61Zy/5U2oSZlDWw=="
-        },
-        "@octokit/plugin-paginate-rest": {
-          "version": "2.16.1",
-          "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.16.1.tgz",
-          "integrity": "sha512-53RGhlRNhQVepZq063YCoIssZkAYjIU1kWQi9m7Qjdq/1IiuZOB9iSHdjDQmKtHWDRSqNwbtsX+tlJNhP1DHEQ==",
-          "requires": {
-            "@octokit/types": "^6.27.1"
-          }
-        },
-        "@octokit/plugin-rest-endpoint-methods": {
-          "version": "5.10.2",
-          "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.10.2.tgz",
-          "integrity": "sha512-Q1QdPqA1HuKbXBuUnyNEImp948htcxgOVwUFTbUbRUsWSJPhabDe3Imd+C8vZg2czpBkl9uR8zx71WE1CP9TxA==",
-          "requires": {
-            "@octokit/types": "^6.27.1",
-            "deprecation": "^2.3.1"
-          }
-        },
-        "@octokit/request": {
-          "version": "5.6.1",
-          "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.1.tgz",
-          "integrity": "sha512-Ls2cfs1OfXaOKzkcxnqw5MR6drMA/zWX/LIS/p8Yjdz7QKTPQLMsB3R+OvoxE6XnXeXEE2X7xe4G4l4X0gRiKQ==",
-          "requires": {
-            "@octokit/endpoint": "^6.0.1",
-            "@octokit/request-error": "^2.1.0",
-            "@octokit/types": "^6.16.1",
-            "is-plain-object": "^5.0.0",
-            "node-fetch": "^2.6.1",
-            "universal-user-agent": "^6.0.0"
-          }
-        },
-        "@octokit/request-error": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
-          "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
-          "requires": {
-            "@octokit/types": "^6.0.3",
-            "deprecation": "^2.0.0",
-            "once": "^1.4.0"
-          }
-        },
         "@octokit/types": {
-          "version": "6.27.1",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.27.1.tgz",
-          "integrity": "sha512-p8VR2OTO1ozxqdAvPeCDDMNmcBzkOL6sPogy2MaEQCapbeWcWNDbwZnqMT3VTZ0DLBBAO0PyHYzU8bA99zd1Fg==",
+          "version": "6.31.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.31.0.tgz",
+          "integrity": "sha512-xobpvYmMYoFSxZB6jL1TPTMMZkxZIBlY145ZKibBJDKCczP1FrLLougtuVOZywGVZdcYs8oq2Bxb3aMjqIFeiw==",
           "requires": {
-            "@octokit/openapi-types": "^10.1.4"
+            "@octokit/openapi-types": "^10.5.0"
           }
-        },
-        "before-after-hook": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
-          "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ=="
         },
         "is-plain-object": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
           "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+        }
+      }
+    },
+    "@octokit/request-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
+      "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
+      "requires": {
+        "@octokit/types": "^6.0.3",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "dependencies": {
+        "@octokit/types": {
+          "version": "6.31.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.31.0.tgz",
+          "integrity": "sha512-xobpvYmMYoFSxZB6jL1TPTMMZkxZIBlY145ZKibBJDKCczP1FrLLougtuVOZywGVZdcYs8oq2Bxb3aMjqIFeiw==",
+          "requires": {
+            "@octokit/openapi-types": "^10.5.0"
+          }
+        }
+      }
+    },
+    "@octokit/rest": {
+      "version": "18.11.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.11.0.tgz",
+      "integrity": "sha512-e30+ERbA4nXkzkaCDgfxS9H1A43Z1GvV5nqLfkxS81rYKbFE6+sEsrXsTRzV1aWLsRIQ+B75Vgnyzjw/ioTyVA==",
+      "requires": {
+        "@octokit/core": "^3.5.1",
+        "@octokit/plugin-paginate-rest": "^2.16.0",
+        "@octokit/plugin-request-log": "^1.0.4",
+        "@octokit/plugin-rest-endpoint-methods": "5.11.1"
+      },
+      "dependencies": {
+        "@octokit/plugin-paginate-rest": {
+          "version": "2.16.4",
+          "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.16.4.tgz",
+          "integrity": "sha512-33UFvlgJP1zQVcbkeMQhzUeEXMOOr1U/3i8GDJqzw9MMRy90P/J+PXfgQvhE0N/rfX01DnY2IQMb2Q/L01EL0A==",
+          "requires": {
+            "@octokit/types": "^6.30.0"
+          }
+        },
+        "@octokit/plugin-rest-endpoint-methods": {
+          "version": "5.11.1",
+          "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.11.1.tgz",
+          "integrity": "sha512-EE69SuO08wtnIy9q/HftGDr7/Im1txzDfeYr+I4T/JkMSNEiedUUE5RuCWkEQAwwbeEU4kVTwSEQZb9Af77/PA==",
+          "requires": {
+            "@octokit/types": "^6.30.0",
+            "deprecation": "^2.3.1"
+          }
+        },
+        "@octokit/types": {
+          "version": "6.31.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.31.0.tgz",
+          "integrity": "sha512-xobpvYmMYoFSxZB6jL1TPTMMZkxZIBlY145ZKibBJDKCczP1FrLLougtuVOZywGVZdcYs8oq2Bxb3aMjqIFeiw==",
+          "requires": {
+            "@octokit/openapi-types": "^10.5.0"
+          }
         }
       }
     },
@@ -1761,9 +1745,9 @@
       }
     },
     "before-after-hook": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
-      "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A=="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
+      "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ=="
     },
     "bluebird": {
       "version": "3.7.2",
@@ -2539,9 +2523,9 @@
           }
         },
         "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
           "dev": true
         },
         "semver": {
@@ -3376,9 +3360,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
@@ -3806,9 +3790,9 @@
           "dev": true
         },
         "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
           "dev": true
         },
         "string-width": {
@@ -5620,9 +5604,9 @@
       }
     },
     "js-base64": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.1.tgz",
-      "integrity": "sha512-XyYXEUTP3ykPPnGPoesMr4yBygopit99iXW52yT1EWrkzwzvtAor/pbf+EBuDkwqSty7K10LeTjCkUn8c166aQ=="
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
+      "integrity": "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -6337,9 +6321,9 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.4.tgz",
-      "integrity": "sha512-aD1fO+xtLiSCc9vuD+sYMxpIuQyhHscGSkBEo2o5LTV/3bTEAYvdUii29n8LlO5uLCmWdGP7uVUVXFo5SRdkLA==",
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
+      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
       "requires": {
         "whatwg-url": "^5.0.0"
       },
@@ -6661,9 +6645,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "path-type": {
@@ -7588,9 +7572,9 @@
           "dev": true
         },
         "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
           "dev": true
         },
         "string-width": {
@@ -8179,9 +8163,9 @@
       "dev": true
     },
     "yargs": {
-      "version": "17.1.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.1.1.tgz",
-      "integrity": "sha512-c2k48R0PwKIqKhPMWjeiF6y2xY/gPMUlro0sgxqXpbOIohWiLNXWslsootttv7E1e73QPAMQSg5FeySbVcpsPQ==",
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.2.0.tgz",
+      "integrity": "sha512-UPeZv4h9Xv510ibpt5rdsUNzgD78nMa1rhxxCgvkKiq06hlKCEHJLiJ6Ub8zDg/wR6hedEI6ovnd2vCvJ4nusA==",
       "requires": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -62,18 +62,19 @@
   "dependencies": {
     "@actions/core": "^1.5.0",
     "@actions/github": "^4.0.0",
+    "@octokit/core": "^3.5.1",
     "@octokit/plugin-throttling": "^3.5.2",
-    "@octokit/rest": "^18.10.0",
+    "@octokit/rest": "^18.11.0",
     "ec2-spot-notification": "^2.0.3",
     "form-data": "^3.0.1",
     "fs-extra": "^9.1.0",
     "git-url-parse": "^11.6.0",
     "globby": "^11.0.4",
     "https-proxy-agent": "^5.0.0",
-    "js-base64": "^3.7.1",
+    "js-base64": "^3.7.2",
     "kebabcase-keys": "^1.0.0",
     "mmmagic": "^0.5.3",
-    "node-fetch": "^2.6.4",
+    "node-fetch": "^2.6.5",
     "node-forge": "^0.10.0",
     "node-ssh": "^12.0.0",
     "pseudoexec": "^0.1.4",
@@ -84,7 +85,7 @@
     "tempy": "^0.6.0",
     "which": "^2.0.2",
     "winston": "^3.3.3",
-    "yargs": "^17.1.1"
+    "yargs": "^17.2.0"
   },
   "devDependencies": {
     "eslint": "^6.8.0",


### PR DESCRIPTION
`npm audit fix && npm upgrade` and install missing peer dependency (@octokit/core) so `npm` stops complaining

Additionally, fixes a merge mistake that interleaved deprecated identifiers with the new code