### PR TITLE
Use global CML_TOKEN instead of REPO_TOKEN

### DIFF
--- a/bin/cml.js
+++ b/bin/cml.js
@@ -58,6 +58,11 @@ const options = {
     coerce: (value) => configureLogger(value) && value,
     choices: ['error', 'warn', 'info', 'debug'],
     default: 'info'
+  },
+  token: {
+    type: 'string',
+    defaultDescription: '$CML_TOKEN',
+    description: 'Repository access token'
   }
 };
 
@@ -71,19 +76,22 @@ const legacyEnvironmentVariables = {
   RUNNER_NO_RETRY: 'CML_RUNNER_NO_RETRY',
   RUNNER_DRIVER: 'CML_RUNNER_DRIVER',
   RUNNER_REPO: 'CML_RUNNER_REPO',
-  RUNNER_PATH: 'CML_RUNNER_PATH'
+  RUNNER_PATH: 'CML_RUNNER_PATH',
+  REPO_TOKEN: 'CML_TOKEN',
+  repo_token: 'CML_TOKEN'
 };
 
 for (const [oldName, newName] of Object.entries(legacyEnvironmentVariables)) {
-  if (process.env[oldName]) process.env[newName] = process.env[oldName];
+  if (process.env[oldName] && !process.env[newName])
+    process.env[newName] = process.env[oldName];
 }
 
 yargs
   .fail(handleError)
   .env('CML')
   .options(options)
-  .commandDir('./cml', { exclude: /\.test\.js$/ })
   .command('$0 <command>', false, (builder) => builder.strict(false), runPlugin)
+  .commandDir('./cml', { exclude: /\.test\.js$/ })
   .recommendCommands()
   .demandCommand()
   .strict()

--- a/bin/cml.test.js
+++ b/bin/cml.test.js
@@ -21,7 +21,8 @@ Options:
   --help     Show help                                                 [boolean]
   --version  Show version number                                       [boolean]
   --log      Maximum log level
-          [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]"
+          [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
+  --token    Repository access token              [string] [default: $CML_TOKEN]"
 `);
   });
 });

--- a/bin/cml/pr.js
+++ b/bin/cml/pr.js
@@ -39,11 +39,6 @@ exports.builder = (yargs) =>
         description:
           'Specifies the repo to be used. If not specified is extracted from the CI ENV.'
       },
-      token: {
-        type: 'string',
-        description:
-          'Personal access token to be used. If not specified in extracted from ENV REPO_TOKEN.'
-      },
       driver: {
         type: 'string',
         choices: ['github', 'gitlab'],

--- a/bin/cml/pr.test.js
+++ b/bin/cml/pr.test.js
@@ -14,14 +14,13 @@ Options:
   --version     Show version number                                    [boolean]
   --log         Maximum log level
           [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
+  --token       Repository access token           [string] [default: $CML_TOKEN]
   --md          Output in markdown format [](url).                     [boolean]
   --remote      Sets git remote.                    [string] [default: \\"origin\\"]
   --user-email  Sets git user email.   [string] [default: \\"olivaw@iterative.ai\\"]
   --user-name   Sets git user name.            [string] [default: \\"Olivaw[bot]\\"]
   --repo        Specifies the repo to be used. If not specified is extracted
                 from the CI ENV.                                        [string]
-  --token       Personal access token to be used. If not specified in extracted
-                from ENV REPO_TOKEN.                                    [string]
   --driver      If not specify it infers it from the ENV.
                                           [string] [choices: \\"github\\", \\"gitlab\\"]"
 `);

--- a/bin/cml/publish.js
+++ b/bin/cml/publish.js
@@ -65,11 +65,6 @@ exports.builder = (yargs) =>
         description:
           'Specifies the repo to be used. If not specified is extracted from the CI ENV.'
       },
-      token: {
-        type: 'string',
-        description:
-          'Personal access token to be used. If not specified, extracted from ENV REPO_TOKEN, GITLAB_TOKEN, GITHUB_TOKEN, or BITBUCKET_TOKEN.'
-      },
       driver: {
         type: 'string',
         choices: ['github', 'gitlab'],

--- a/bin/cml/publish.test.js
+++ b/bin/cml/publish.test.js
@@ -15,6 +15,8 @@ Options:
       --version                   Show version number                  [boolean]
       --log                       Maximum log level
           [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
+      --token                     Repository access token
+                                                  [string] [default: $CML_TOKEN]
       --md                        Output in markdown format [title ||
                                   name](url).                          [boolean]
   -t, --title                     Markdown title [title](url) or ![](url title).
@@ -30,10 +32,6 @@ Options:
       --repo                      Specifies the repo to be used. If not
                                   specified is extracted from the CI ENV.
                                                                         [string]
-      --token                     Personal access token to be used. If not
-                                  specified, extracted from ENV REPO_TOKEN,
-                                  GITLAB_TOKEN, GITHUB_TOKEN, or
-                                  BITBUCKET_TOKEN.                      [string]
       --driver                    If not specify it infers it from the ENV.
                                           [string] [choices: \\"github\\", \\"gitlab\\"]"
 `);

--- a/bin/cml/runner.js
+++ b/bin/cml/runner.js
@@ -446,11 +446,6 @@ exports.builder = (yargs) =>
         description:
           'Repository to be used for registering the runner. If not specified, it will be inferred from the environment'
       },
-      token: {
-        type: 'string',
-        description:
-          'Personal access token to register a self-hosted runner on the repository. If not specified, it will be inferred from the environment'
-      },
       cloud: {
         type: 'string',
         choices: ['aws', 'azure', 'gcp', 'kubernetes'],

--- a/bin/cml/runner.test.js
+++ b/bin/cml/runner.test.js
@@ -14,6 +14,8 @@ Options:
   --version                   Show version number                      [boolean]
   --log                       Maximum log level
           [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
+  --token                     Repository access token
+                                                  [string] [default: $CML_TOKEN]
   --labels                    One or more user-defined labels for this runner
                               (delimited with commas)  [string] [default: \\"cml\\"]
   --idle-timeout              Seconds to wait for jobs before shutting down. Set
@@ -31,9 +33,6 @@ Options:
   --repo                      Repository to be used for registering the runner.
                               If not specified, it will be inferred from the
                               environment                               [string]
-  --token                     Personal access token to register a self-hosted
-                              runner on the repository. If not specified, it
-                              will be inferred from the environment     [string]
   --cloud                     Cloud to deploy the runner
                          [string] [choices: \\"aws\\", \\"azure\\", \\"gcp\\", \\"kubernetes\\"]
   --cloud-region              Region where the instance is deployed. Choices:

--- a/bin/cml/send-comment.js
+++ b/bin/cml/send-comment.js
@@ -36,11 +36,6 @@ exports.builder = (yargs) =>
         description:
           'Specifies the repo to be used. If not specified is extracted from the CI ENV.'
       },
-      token: {
-        type: 'string',
-        description:
-          'Personal access token to be used. If not specified is extracted from ENV REPO_TOKEN.'
-      },
       driver: {
         type: 'string',
         choices: ['github', 'gitlab', 'bitbucket'],

--- a/bin/cml/send-comment.test.js
+++ b/bin/cml/send-comment.test.js
@@ -23,6 +23,8 @@ Options:
   --version                 Show version number                        [boolean]
   --log                     Maximum log level
           [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
+  --token                   Repository access token
+                                                  [string] [default: $CML_TOKEN]
   --commit-sha, --head-sha  Commit SHA linked to this comment. Defaults to HEAD.
                                                                         [string]
   --update                  Update the last CML comment (if any) instead of
@@ -32,8 +34,6 @@ Options:
                             to provide extra functionality.            [boolean]
   --repo                    Specifies the repo to be used. If not specified is
                             extracted from the CI ENV.                  [string]
-  --token                   Personal access token to be used. If not specified
-                            is extracted from ENV REPO_TOKEN.           [string]
   --driver                  If not specify it infers it from the ENV.
                              [string] [choices: \\"github\\", \\"gitlab\\", \\"bitbucket\\"]"
 `);

--- a/bin/cml/send-github-check.js
+++ b/bin/cml/send-github-check.js
@@ -42,11 +42,6 @@ exports.builder = (yargs) =>
         type: 'string',
         description:
           'Specifies the repo to be used. If not specified is extracted from the CI ENV.'
-      },
-      token: {
-        type: 'string',
-        description:
-          'Personal access token to be used. If not specified in extracted from ENV REPO_TOKEN.'
       }
     })
   );

--- a/bin/cml/send-github-check.test.js
+++ b/bin/cml/send-github-check.test.js
@@ -43,6 +43,8 @@ Options:
   --version                 Show version number                        [boolean]
   --log                     Maximum log level
           [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
+  --token                   Repository access token
+                                                  [string] [default: $CML_TOKEN]
   --commit-sha, --head-sha  Commit SHA linked to this comment. Defaults to HEAD.
                                                                         [string]
   --conclusion              Sets the conclusion status of the check.
@@ -51,9 +53,7 @@ Options:
   --title                   Sets title of the check.
                                                 [string] [default: \\"CML Report\\"]
   --repo                    Specifies the repo to be used. If not specified is
-                            extracted from the CI ENV.                  [string]
-  --token                   Personal access token to be used. If not specified
-                            in extracted from ENV REPO_TOKEN.           [string]"
+                            extracted from the CI ENV.                  [string]"
 `);
   });
 });

--- a/bin/cml/tensorboard-dev.test.js
+++ b/bin/cml/tensorboard-dev.test.js
@@ -64,6 +64,7 @@ Options:
       --version       Show version number                              [boolean]
       --log           Maximum log level
           [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
+      --token         Repository access token     [string] [default: $CML_TOKEN]
   -c, --credentials   TB credentials as json. Usually found at
                       ~/.config/tensorboard/credentials/uploader-creds.json. If
                       not specified will look for the json at the env variable

--- a/src/cml.js
+++ b/src/cml.js
@@ -34,16 +34,8 @@ const gitRemoteUrl = (opts = {}) => {
 };
 
 const inferToken = () => {
-  const {
-    REPO_TOKEN,
-    repo_token: repoToken,
-    GITHUB_TOKEN,
-    GITLAB_TOKEN,
-    BITBUCKET_TOKEN
-  } = process.env;
-  return (
-    REPO_TOKEN || repoToken || GITHUB_TOKEN || GITLAB_TOKEN || BITBUCKET_TOKEN
-  );
+  const { GITHUB_TOKEN, GITLAB_TOKEN, BITBUCKET_TOKEN } = process.env;
+  return GITHUB_TOKEN || GITLAB_TOKEN || BITBUCKET_TOKEN;
 };
 
 const inferDriver = (opts = {}) => {


### PR DESCRIPTION
It should be backwards compatible. 

Closes #763; **~un~tested**, not working.