### PR TITLE
v0.7.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvcorg/cml",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvcorg/cml",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "author": {
     "name": "DVC",
     "url": "http://cml.dev"


### PR DESCRIPTION
 - Cloud metadata (#748)
 - Use automatically configured proxy agent (#765)
 - Update licence year + company (#756)
 - Fix cml runner --cloud-gpu to accept nogpu (#747)