### PR TITLE
Separate headSha from triggerSha

### DIFF
--- a/src/cml.js
+++ b/src/cml.js
@@ -83,8 +83,12 @@ class CML {
   }
 
   async headSha() {
+    return exec(`git rev-parse HEAD`);
+  }
+
+  async triggerSha() {
     const { sha } = getDriver(this);
-    return sha || (await exec(`git rev-parse HEAD`));
+    return sha || (await this.headSha());
   }
 
   async branch() {
@@ -165,7 +169,7 @@ class CML {
   }
 
   async checkCreate(opts = {}) {
-    const { headSha = await this.headSha() } = opts;
+    const { headSha = await this.triggerSha() } = opts;
 
     return await getDriver(this).checkCreate({ ...opts, headSha });
   }
@@ -334,7 +338,7 @@ class CML {
       return;
     }
 
-    const sha = await this.headSha();
+    const sha = await this.triggerSha();
     const shaShort = sha.substr(0, 8);
 
     const target = await this.branch();


### PR DESCRIPTION
Closes #788, see https://github.com/iterative/cml/issues/788#issuecomment-954310530 for context.

#### Variable separation
* `headSha` — always the hash of the last commit
* `triggerSha` — preferably the hash of the commit that triggered the workflow, fallback to `headSha`