### PR TITLE
Improve BitBucket unauthorized error message

### DIFF
--- a/src/drivers/bitbucket_cloud.js
+++ b/src/drivers/bitbucket_cloud.js
@@ -253,10 +253,14 @@ class BitbucketCloud {
     });
 
     if (response.status > 300) {
-      const {
-        error: { message }
-      } = await response.json();
-      throw new Error(`${response.statusText} ${message}`);
+      try {
+        const {
+          error: { message }
+        } = await response.json();
+        throw new Error(`${response.statusText} ${message}`);
+      } catch (err) {
+        throw new Error(`${response.statusText}`);
+      }
     }
 
     return await response.json();

--- a/src/drivers/bitbucket_cloud.js
+++ b/src/drivers/bitbucket_cloud.js
@@ -257,9 +257,9 @@ class BitbucketCloud {
         const {
           error: { message }
         } = await response.json();
-        throw new Error(`${response.statusText} ${message}`);
+        throw new Error(message);
       } catch (err) {
-        throw new Error(`${response.statusText}`);
+        throw new Error(`${response.statusText} ${err.message}`);
       }
     }
 


### PR DESCRIPTION
Was playing around with CML for some integration work with Studio when I encountered this papercut.

On 401 unauthorized responses, the BitBucket API does not always return a JSON body. That was causing the error handling code that's being changed here to throw an error itself, which led to errors like:

```
error: invalid json response body at [url] reason: Unexpected end of JSON input {"type":"invalid-json"}
```

Which was a bit confusing to me. This commit changes the error handling code to return a generic error message instead. So with an incorrect BitBucket token, CML now prints:

```
error: Unauthorized
```

Which should be a little more helpful to the user.

NB: My JS is not the best ever, so if something looks weird / unidiomatic, it probably is. Please let me know if you'd like to see any changes :)