### PR TITLE
Actions ci 

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -9,8 +9,8 @@ on:
 jobs:
   authorize:
     if:
-      ${{ github.event_name != 'pull_request' || github.event.pull_request.draft
-      == false }}
+      ${{ github.event_name != 'pull_request_target' ||
+      github.event.pull_request_target.draft == false }}
     environment:
       ${{ (github.event_name == 'pull_request_target' &&
       github.event.pull_request.head.repo.full_name != github.repository) &&

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
 jobs:
   authorize:
+    if:
+      ${{ github.event_name != 'pull_request' || github.event.pull_request.draft
+      == false }}
     environment:
       ${{ (github.event_name == 'pull_request_target' &&
       github.event.pull_request.head.repo.full_name != github.repository) &&


### PR DESCRIPTION
reduce action spam, don't request deployment while PRs are a "draft"