### PR TITLE
deploy: autorelease on tags

### DIFF
--- a/.github/workflows/checkbot.yml
+++ b/.github/workflows/checkbot.yml
@@ -146,3 +146,29 @@ jobs:
           npm ci
           sudo npm link
           # ${{ github.event.comment.body }}
+  tag: # /tag <tagname> <commit>
+    needs: react-seen
+    if: startsWith(github.event.comment.body, '/tag ')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Tag Commit
+        run: |
+          git clone https://${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY} repo
+          git -C repo tag $(echo "$BODY" | awk '{print $2" "$3}')
+          git -C repo push --tags
+          rm -rf repo
+        env:
+          BODY: ${{ github.event.comment.body }}
+          GITHUB_TOKEN: ${{ secrets.TEST_GITHUB_TOKEN }}
+      - name: React Success
+        uses: actions/github-script@v2
+        with:
+          script: |
+            post = (context.eventName == "issue_comment"
+              ? github.reactions.createForIssueComment
+              : github.reactions.createForPullRequestReviewComment)
+            post({
+              owner: context.repo.owner, repo: context.repo.repo,
+              comment_id: context.payload.comment.id, content: "rocket"})
+          github-token: ${{ secrets.TEST_GITHUB_TOKEN }}

--- a/.github/workflows/checkbot.yml
+++ b/.github/workflows/checkbot.yml
@@ -6,6 +6,7 @@ on:
     types: [created]
 jobs:
   react-seen:
+    if: startsWith(github.event.comment.body, '/')
     runs-on: ubuntu-latest
     steps:
       - name: React Seen

--- a/.github/workflows/checkbot.yml
+++ b/.github/workflows/checkbot.yml
@@ -2,11 +2,11 @@ name: checkbot
 on:
   issue_comment:
     types: [created]
+  pull_request_review_comment:
+    types: [created]
 jobs:
-  # check that CML container builds properly
-  build-container:
-    if: startsWith(github.event.comment.body, '/tests')
-    runs-on: ubuntu-18.04
+  react-seen:
+    runs-on: ubuntu-latest
     steps:
       - name: React Seen
         uses: actions/github-script@v2
@@ -15,16 +15,25 @@ jobs:
             const perm = await github.repos.getCollaboratorPermissionLevel({
               owner: context.repo.owner, repo: context.repo.repo,
               username: context.payload.comment.user.login})
+            post = (context.eventName == "issue_comment"
+              ? github.reactions.createForIssueComment
+              : github.reactions.createForPullRequestReviewComment)
             if (!["admin", "write"].includes(perm.data.permission)){
-              github.reactions.createForIssueComment({
+              post({
                 owner: context.repo.owner, repo: context.repo.repo,
                 comment_id: context.payload.comment.id, content: "laugh"})
               throw "Permission denied for user " + context.payload.comment.user.login
             }
-            github.reactions.createForIssueComment({
+            post({
               owner: context.repo.owner, repo: context.repo.repo,
               comment_id: context.payload.comment.id, content: "eyes"})
           github-token: ${{ secrets.TEST_GITHUB_TOKEN }}
+  # check that CML container builds properly
+  build-container:
+    needs: react-seen
+    if: startsWith(github.event.comment.body, '/tests')
+    runs-on: ubuntu-18.04
+    steps:
       - uses: actions/checkout@v2
       - name: Build & Publish test image
         run: |
@@ -127,44 +136,13 @@ jobs:
         run: |
           nvidia-smi
   chatbot:
+    needs: react-seen
     if: startsWith(github.event.comment.body, '/cml-')
     runs-on: ubuntu-latest
     steps:
-      - name: React Seen
-        uses: actions/github-script@v2
-        with:
-          script: |
-            const perm = await github.repos.getCollaboratorPermissionLevel({
-              owner: context.repo.owner, repo: context.repo.repo,
-              username: context.payload.comment.user.login})
-            if (!["admin", "write"].includes(perm.data.permission)){
-              github.reactions.createForIssueComment({
-                owner: context.repo.owner, repo: context.repo.repo,
-                comment_id: context.payload.comment.id, content: "laugh"})
-              throw "Permission denied for user " + context.payload.comment.user.login
-            }
-            github.reactions.createForIssueComment({
-              owner: context.repo.owner, repo: context.repo.repo,
-              comment_id: context.payload.comment.id, content: "eyes"})
-          github-token: ${{ secrets.TEST_GITHUB_TOKEN }}
       - uses: actions/checkout@v2
-      - name: chatops
-        id: chatops
-        uses: actions/github-script@v1
-        env:
-          COMMAND: ${{github.event.comment.body}}
-        with:
-          github-token: ${{ secrets.TEST_GITHUB_TOKEN }}
-          script: |
-            github.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.issue.number
-            }).then( (pr) => {
-              console.log(`::set-output name=COMMAND::${process.env.COMMAND}`)
-            })
       - name: chatactions
         run: |
           npm ci
           sudo npm link
-          # ${{steps.chatops.outputs.COMMAND}}
+          # ${{ github.event.comment.body }}

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -2,8 +2,8 @@ name: Test & Deploy
 on:
   schedule:
     - cron: '0 9 * * 1' # M H d m w (Mondays at 9:00)
-  release:
-    types: [published]
+  push:
+    tags: ['v*']
   pull_request_target:
   workflow_dispatch:
 jobs:
@@ -89,10 +89,24 @@ jobs:
           registry-url: https://registry.npmjs.org
       - run: npm install
       - run:
-          npm ${{ github.event_name == 'release' && 'publish' || 'publish
+          npm ${{ github.event_name == 'push' && 'publish' || 'publish
           --dry-run' }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  release:
+    if: github.event_name == 'push'
+    needs: packages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - id: meta
+        name: Metadata
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/tags/}
+      - uses: softprops/action-gh-release@v1
+        with:
+          name: CML ${{ steps.meta.outputs.tag }}
+          draft: true
+          generate_release_notes: true
   images:
     runs-on: ubuntu-latest
     needs: packages
@@ -183,8 +197,8 @@ jobs:
       - uses: docker/build-push-action@v2
         with:
           push:
-            ${{ github.event_name == 'release' || github.event_name ==
-            'schedule' || github.event_name == 'workflow_dispatch' }}
+            ${{ github.event_name == 'push' || github.event_name == 'schedule'
+            || github.event_name == 'workflow_dispatch' }}
           context: ./
           file: ./Dockerfile
           tags: |


### PR DESCRIPTION
Fixes #845

- [x] auto-draft release notes on tag push
  - facilitates adding release assets easily in future (for #842)
- [x] tidy checkbot
- [x] add tagbot
- [ ] Release method (to be updated in https://cml.dev/doc/contributing/core post-merge):

```diff
  - `git checkout master && git pull && git checkout -b M.m.p && npm version M.m.p && git push && gh pr create`
  - Merge the resulting PR
- - Draft a new [release](https://github.com/iterative/cml/releases), ensuring
-   all commits since last release are summarised in the release notes
+ - `git checkout master && git pull && git tag -f vM.m.p && git push --tags`
+    or comment `/tag vM.m.p SHA` in the PR
+ - Wait for a draft to appear under [releases](https://github.com/iterative/cml/releases)
+ - Check & publish the draft
```
