### PR TITLE
`github-send-check` usage warnings

### DIFF
--- a/bin/cml/send-github-check.js
+++ b/bin/cml/send-github-check.js
@@ -33,6 +33,12 @@ exports.builder = (yargs) =>
         default: 'success',
         description: 'Sets the conclusion status of the check.'
       },
+      status: {
+        type: 'string',
+        choices: ['queued', 'in_progress', 'completed'],
+        default: 'completed',
+        description: 'Sets the status of the check.'
+      },
       title: {
         type: 'string',
         default: 'CML Report',
@@ -46,7 +52,7 @@ exports.builder = (yargs) =>
       token: {
         type: 'string',
         description:
-          'Personal access token to be used. If not specified in extracted from ENV REPO_TOKEN.'
+          "GITHUB_TOKEN or Github App token. Personal access token won't work"
       }
     })
   );

--- a/bin/cml/send-github-check.test.js
+++ b/bin/cml/send-github-check.test.js
@@ -34,26 +34,29 @@ describe('CML e2e', () => {
     const output = await exec(`node ./bin/cml.js send-github-check --help`);
 
     expect(output).toMatchInlineSnapshot(`
-"cml.js send-github-check <markdown file>
+      "cml.js send-github-check <markdown file>
 
-Create a check report
+      Create a check report
 
-Options:
-  --help                    Show help                                  [boolean]
-  --version                 Show version number                        [boolean]
-  --log                     Maximum log level
-          [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
-  --commit-sha, --head-sha  Commit SHA linked to this comment. Defaults to HEAD.
-                                                                        [string]
-  --conclusion              Sets the conclusion status of the check.
-     [string] [choices: \\"success\\", \\"failure\\", \\"neutral\\", \\"cancelled\\", \\"skipped\\",
-                                               \\"timed_out\\"] [default: \\"success\\"]
-  --title                   Sets title of the check.
-                                                [string] [default: \\"CML Report\\"]
-  --repo                    Specifies the repo to be used. If not specified is
-                            extracted from the CI ENV.                  [string]
-  --token                   Personal access token to be used. If not specified
-                            in extracted from ENV REPO_TOKEN.           [string]"
-`);
+      Options:
+        --help                    Show help                                  [boolean]
+        --version                 Show version number                        [boolean]
+        --log                     Maximum log level
+                [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
+        --commit-sha, --head-sha  Commit SHA linked to this comment. Defaults to HEAD.
+                                                                              [string]
+        --conclusion              Sets the conclusion status of the check.
+           [string] [choices: \\"success\\", \\"failure\\", \\"neutral\\", \\"cancelled\\", \\"skipped\\",
+                                                     \\"timed_out\\"] [default: \\"success\\"]
+        --status                  Sets the status of the check.
+                    [string] [choices: \\"queued\\", \\"in_progress\\", \\"completed\\"] [default:
+                                                                          \\"completed\\"]
+        --title                   Sets title of the check.
+                                                      [string] [default: \\"CML Report\\"]
+        --repo                    Specifies the repo to be used. If not specified is
+                                  extracted from the CI ENV.                  [string]
+        --token                   GITHUB_TOKEN or Github App token. Personal access
+                                  token won't work                            [string]"
+    `);
   });
 });

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -22,7 +22,10 @@ const {
   GITHUB_REF,
   GITHUB_HEAD_REF,
   GITHUB_EVENT_NAME,
-  GITHUB_RUN_ID
+  GITHUB_RUN_ID,
+  GITHUB_TOKEN,
+  CI,
+  TPI_TASK
 } = process.env;
 
 const branchName = (branch) => {
@@ -164,6 +167,15 @@ class Github {
       conclusion = 'success',
       status = 'completed'
     } = opts;
+
+    const warning =
+      'This command only works inside a Github runner or a Github app.';
+
+    if (!CI || TPI_TASK) winston.warn(warning);
+    if (GITHUB_TOKEN && GITHUB_TOKEN !== this.token)
+      winston.warn(
+        `Your token is different than the GITHUB_TOKEN, this command does not work with PAT. ${warning}`
+      );
 
     const name = title;
     return await octokit(this.token, this.repo).checks.create({


### PR DESCRIPTION
I haven't found an optimal approach to this aside warn the user that this command can not be used outside a runner or a Github app. 

- closes #829
- Additionally includes the possibility of changing the status 