### PR TITLE
Pin colors to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,9 @@
       "prettier --write"
     ]
   },
+  "resolution": {
+    "colors": "1.4.0"
+  },
   "dependencies": {
     "@actions/core": "^1.6.0",
     "@actions/github": "^4.0.0",
@@ -69,6 +72,7 @@
     "@octokit/core": "^3.5.1",
     "@octokit/plugin-throttling": "^3.5.2",
     "@octokit/rest": "18.0.0",
+    "colors": "1.4.0",
     "ec2-spot-notification": "^2.0.3",
     "form-data": "^3.0.1",
     "fs-extra": "^9.1.0",


### PR DESCRIPTION
Closes #863 by pinning the [`colors`](https://www.npmjs.com/package/colors) package to 1.4.0.