### PR TITLE
Fix magic path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,11 @@
       "dependencies": {
         "@actions/core": "^1.6.0",
         "@actions/github": "^4.0.0",
-        "@npcz/magic": "^1.3.11",
+        "@npcz/magic": "^1.3.12",
         "@octokit/core": "^3.5.1",
         "@octokit/plugin-throttling": "^3.5.2",
         "@octokit/rest": "18.0.0",
+        "colors": "1.4.0",
         "ec2-spot-notification": "^2.0.3",
         "form-data": "^3.0.1",
         "fs-extra": "^9.1.0",
@@ -1142,9 +1143,9 @@
       }
     },
     "node_modules/@npcz/magic": {
-      "version": "1.3.11",
-      "resolved": "https://registry.npmjs.org/@npcz/magic/-/magic-1.3.11.tgz",
-      "integrity": "sha512-TZgZtidH0Bc+qT+AHkuk8qGrlNg/yc6M5pQcnWmfRQ8tNM5yik9zuisUz11CbGmT+4E1eVsZFdN4fzWhREeZLw=="
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/@npcz/magic/-/magic-1.3.12.tgz",
+      "integrity": "sha512-RjcIEozYbbhBxzJd3KE0bhyVL86Da3fubBumIKwT1u5i8XVFXRlaC5KxCoUWKWV3GpdFkOV/93KBIQmwSrHnzw=="
     },
     "node_modules/@octokit/auth-token": {
       "version": "2.5.0",
@@ -8944,9 +8945,9 @@
       }
     },
     "@npcz/magic": {
-      "version": "1.3.11",
-      "resolved": "https://registry.npmjs.org/@npcz/magic/-/magic-1.3.11.tgz",
-      "integrity": "sha512-TZgZtidH0Bc+qT+AHkuk8qGrlNg/yc6M5pQcnWmfRQ8tNM5yik9zuisUz11CbGmT+4E1eVsZFdN4fzWhREeZLw=="
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/@npcz/magic/-/magic-1.3.12.tgz",
+      "integrity": "sha512-RjcIEozYbbhBxzJd3KE0bhyVL86Da3fubBumIKwT1u5i8XVFXRlaC5KxCoUWKWV3GpdFkOV/93KBIQmwSrHnzw=="
     },
     "@octokit/auth-token": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -62,13 +62,17 @@
       "prettier --write"
     ]
   },
+  "resolution": {
+    "colors": "1.4.0"
+  },
   "dependencies": {
     "@actions/core": "^1.6.0",
     "@actions/github": "^4.0.0",
-    "@npcz/magic": "^1.3.11",
+    "@npcz/magic": "^1.3.12",
     "@octokit/core": "^3.5.1",
     "@octokit/plugin-throttling": "^3.5.2",
     "@octokit/rest": "18.0.0",
+    "colors": "1.4.0",
     "ec2-spot-notification": "^2.0.3",
     "form-data": "^3.0.1",
     "fs-extra": "^9.1.0",

--- a/src/utils.js
+++ b/src/utils.js
@@ -28,11 +28,6 @@ const exec = async (command) => {
 
 const mimeType = async (opts) => {
   const { path, buffer } = opts;
-  FileMagic.magicFile = PATH.join(
-    __dirname,
-    '..',
-    'node_modules/@npcz/magic/dist/magic.mgc'
-  );
   FileMagic.defaulFlags = MagicFlags.MAGIC_PRESERVE_ATIME;
   const fileMagic = await FileMagic.getInstance();
 


### PR DESCRIPTION
Would close https://github.com/iterative/setup-cml/issues/56; still doesn't work because of an esoteric path issue involving Windows, Emscripten, `libmagic` and a pinch of salt.

* Upstream fix: [1.3.12](https://github.com/npcz/magic/releases/tag/v1.3.12) https://github.com/npcz/magic/issues/10 