### PR TITLE
Fix --idle-timeout on cml runner --cloud

### DIFF
--- a/src/terraform.js
+++ b/src/terraform.js
@@ -97,11 +97,7 @@ resource "iterative_cml_runner" "runner" {
   ${token ? `token = "${token}"` : ''}
   ${driver ? `driver = "${driver}"` : ''}
   ${labels ? `labels = "${labels}"` : ''}
-  ${
-    typeof idleTimeout !== 'undefined' && idleTimeout >= 0
-      ? `idle_timeout = ${idleTimeout}`
-      : ''
-  }
+  ${typeof idleTimeout !== 'undefined' ? `idle_timeout = ${idleTimeout}` : ''}
   ${name ? `name = "${name}"` : ''}
   ${single ? `single = "${single}"` : ''}
   ${cloud ? `cloud = "${cloud}"` : ''}


### PR DESCRIPTION
Closes #877 

```console
$ cml runner ··· --idle-timeout -1 --cloud ···
info: Preparing workdir /.../.cml/cml-ih4aa0z0w3...
info: Deploying cloud runner plan...
info: Terraform apply...
info: {..., "idleTimeout": -1, ...}
```