### PR TITLE
Add human–readable duration syntax for runner --idle-timeout

### DIFF
--- a/bin/cml/runner.js
+++ b/bin/cml/runner.js
@@ -3,7 +3,7 @@ const { homedir } = require('os');
 const fs = require('fs').promises;
 const { SpotNotifier } = require('ec2-spot-notification');
 const kebabcaseKeys = require('kebabcase-keys');
-
+const timestring = require('timestring');
 const winston = require('winston');
 const CML = require('../../src/cml').default;
 const { exec, randid, sleep } = require('../../src/utils');
@@ -432,10 +432,12 @@ exports.builder = (yargs) =>
           'One or more user-defined labels for this runner (delimited with commas)'
       },
       idleTimeout: {
-        type: 'number',
-        default: 5 * 60,
+        type: 'string',
+        default: '5 minutes',
+        coerce: (val) =>
+          /^-?\d+$/.test(val) ? parseInt(val) : timestring(val),
         description:
-          'Seconds to wait for jobs before shutting down. Set to -1 to disable timeout'
+          'Time to wait for jobs before shutting down. Set to -1 to disable timeout'
       },
       name: {
         type: 'string',

--- a/bin/cml/runner.js
+++ b/bin/cml/runner.js
@@ -437,7 +437,7 @@ exports.builder = (yargs) =>
         coerce: (val) =>
           /^-?\d+$/.test(val) ? parseInt(val) : timestring(val),
         description:
-          'Time to wait for jobs before shutting down. Set to -1 to disable timeout'
+          'Time to wait for jobs before shutting down (e.g. "5min"). Use "never" to disable'
       },
       name: {
         type: 'string',

--- a/bin/cml/runner.test.js
+++ b/bin/cml/runner.test.js
@@ -20,9 +20,10 @@ describe('CML e2e', () => {
         --labels                                  One or more user-defined labels for
                                                   this runner (delimited with commas)
                                                              [string] [default: \\"cml\\"]
-        --idle-timeout                            Seconds to wait for jobs before
+        --idle-timeout                            Time to wait for jobs before
                                                   shutting down. Set to -1 to disable
-                                                  timeout      [number] [default: 300]
+                                                  timeout
+                                                       [string] [default: \\"5 minutes\\"]
         --name                                    Name displayed in the repository
                                                   once registered
                                                           [string] [default: cml-{ID}]

--- a/bin/cml/runner.test.js
+++ b/bin/cml/runner.test.js
@@ -21,8 +21,8 @@ describe('CML e2e', () => {
                                                   this runner (delimited with commas)
                                                              [string] [default: \\"cml\\"]
         --idle-timeout                            Time to wait for jobs before
-                                                  shutting down. Set to -1 to disable
-                                                  timeout
+                                                  shutting down (e.g. \\"5min\\"). Use
+                                                  \\"never\\" to disable
                                                        [string] [default: \\"5 minutes\\"]
         --name                                    Name displayed in the repository
                                                   once registered

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "strip-url-auth": "^1.0.1",
         "tar": "^6.1.11",
         "tempy": "^0.6.0",
+        "timestring": "^6.0.0",
         "which": "^2.0.2",
         "winston": "^3.3.3",
         "yargs": "^17.2.1"
@@ -7349,6 +7350,14 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
+    "node_modules/timestring": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/timestring/-/timestring-6.0.0.tgz",
+      "integrity": "sha512-wMctrWD2HZZLuIlchlkE2dfXJh7J2KDI9Dwl+2abPYg0mswQHfOAyQW3jJg1pY5VfttSINZuKcXoB3FGypVklA==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -13589,6 +13598,11 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
+    },
+    "timestring": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/timestring/-/timestring-6.0.0.tgz",
+      "integrity": "sha512-wMctrWD2HZZLuIlchlkE2dfXJh7J2KDI9Dwl+2abPYg0mswQHfOAyQW3jJg1pY5VfttSINZuKcXoB3FGypVklA=="
     },
     "tmpl": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "strip-url-auth": "^1.0.1",
     "tar": "^6.1.11",
     "tempy": "^0.6.0",
+    "timestring": "^6.0.0",
     "which": "^2.0.2",
     "winston": "^3.3.3",
     "yargs": "^17.2.1"


### PR DESCRIPTION
This pull request enables `cml runner --idle-timeout` to parse human–readable dates with the [`timestring`](https://www.npmjs.com/package/timestring) package.

### Accepted inputs

* `-1` (disabled)
* `300` (5 minutes, implicit seconds)
* `5m30s` (5 minutes, 30 seconds)
* `10 minutes` (10 minutes)

Whitespace–insensitive.

### Technical debt

* https://github.com/mike182uk/timestring/issues/49