### PR TITLE
Move runner tests to AWS sandbox

### DIFF
--- a/.github/workflows/checkbot.yml
+++ b/.github/workflows/checkbot.yml
@@ -1,4 +1,6 @@
 name: checkbot
+permissions:
+  id-token: write
 on:
   issue_comment:
     types: [created]
@@ -58,6 +60,7 @@ jobs:
           BASE_IMAGE: 'ubuntu:20.04'
   # test container all CML features, vega and actions with issues in the past
   check-container:
+    environment: internal
     needs: build-container
     runs-on: ubuntu-18.04
     container: dvcorg/cml-test
@@ -70,10 +73,12 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: '3.x'
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-west-1
+          role-to-assume: arn:aws:iam::342840881361:role/SandboxUser
       - name: CML test
         env:
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,8 +1,7 @@
 deploy-runner:
   image: iterativeai/cml:0-dvc2-base1
   script:
-    - sudo apt update
-    - sudo apt install --yes awscli
+    - pip install awscli
     - >
       CREDENTIALS=($(aws sts assume-role-with-web-identity
       --region=us-west-1

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,7 @@
 deploy-runner:
-  rules:
-    - if: $CI_COMMIT_BRANCH == 'master'
+  only:
+    refs:
+      - master
   image: iterativeai/cml:0-dvc2-base1
   script:
     - pip install awscli

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,9 @@ deploy-runner:
           --labels=cml-runner-gpu
 test-runner:
   needs: [deploy-runner]
+  only:
+    refs:
+      - master
   tags:
     - cml-runner-gpu
   script:
@@ -38,6 +41,9 @@ test-runner:
     - nvidia-smi
 test-container:
   needs: [deploy-runner]
+  only:
+    refs:
+      - master
   tags:
     - cml-runner-gpu
   image: iterativeai/cml:0-dvc2-base1-gpu

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,20 @@
 deploy-runner:
   image: iterativeai/cml:0-dvc2-base1
   script:
+    - sudo apt update
+    - sudo apt install --yes awscli
+    - >
+      CREDENTIALS=($(aws sts assume-role-with-web-identity
+      --region=us-west-1
+      --role-arn=arn:aws:iam::342840881361:role/SandboxUser
+      --role-session-name=GitLab
+      --duration-seconds=3600
+      --web-identity-token="$CI_JOB_JWT_V2"
+      --query="Credentials.[AccessKeyId,SecretAccessKey,SessionToken]"
+      --output=text))
+    - export AWS_ACCESS_KEY_ID="${CREDENTIALS[0]}"
+    - export AWS_SECRET_ACCESS_KEY="${CREDENTIALS[1]}"
+    - export AWS_SESSION_TOKEN="${CREDENTIALS[2]}"
     - |
       cml runner \
           --cloud=aws \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,6 @@
 deploy-runner:
+  rules:
+    - if: $CI_COMMIT_BRANCH == 'master'
   image: iterativeai/cml:0-dvc2-base1
   script:
     - pip install awscli

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,6 @@
 deploy-runner:
   only:
-    refs:
-      - master
+    refs: [master]
   image: iterativeai/cml:0-dvc2-base1
   script:
     - pip install awscli
@@ -27,8 +26,7 @@ deploy-runner:
 test-runner:
   needs: [deploy-runner]
   only:
-    refs:
-      - master
+    refs: [master]
   tags:
     - cml-runner-gpu
   script:
@@ -42,8 +40,7 @@ test-runner:
 test-container:
   needs: [deploy-runner]
   only:
-    refs:
-      - master
+    refs: [master]
   tags:
     - cml-runner-gpu
   image: iterativeai/cml:0-dvc2-base1-gpu


### PR DESCRIPTION
Part of https://github.com/iterative/itops/issues/111; needs testing on GitLab.


⚠️ Don't forget to remove the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` secrets after merging.

Partially closes https://github.com/iterative/itops/issues/111