### PR TITLE
Fix publish magic.mgc altered by babel

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -94,10 +94,12 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: build
         run: |
+          cp node_modules/@npcz/magic/dist/magic.mgc assets/magic.mgc
           npx --yes pkg package.json
           for cmd in '' runner publish pr; do
             build/cml-linux $cmd --version
           done
+          rm assets/magic.mgc
   release:
     if: github.event_name == 'push'
     needs: packages
@@ -109,7 +111,9 @@ jobs:
         run: |
           echo ::set-output name=tag::${GITHUB_REF#refs/tags/}
           npm install
+          cp node_modules/@npcz/magic/dist/magic.mgc assets/magic.mgc
           npx --yes pkg package.json
+          rm assets/magic.mgc
       - uses: softprops/action-gh-release@v1
         with:
           name: CML ${{ steps.build.outputs.tag }}

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -96,10 +96,10 @@ jobs:
         run: |
           cp node_modules/@npcz/magic/dist/magic.mgc assets/magic.mgc
           npx --yes pkg package.json
+          rm assets/magic.mgc
           for cmd in '' runner publish pr; do
             build/cml-linux $cmd --version
           done
-          rm assets/magic.mgc
   release:
     if: github.event_name == 'push'
     needs: packages

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "assets": [
       "**/*.js",
       "node_modules/@npcz/magic/dist/*.wasm",
+      "node_modules/@npcz/magic/dist/magic.mgc",
       "assets/magic.mgc"
     ],
     "targets": [

--- a/package.json
+++ b/package.json
@@ -119,7 +119,8 @@
     "bin": "bin/cml.js",
     "assets": [
       "**/*.js",
-      "node_modules/@npcz/magic/**/*"
+      "node_modules/@npcz/magic/dist/*.wasm",
+      "assets/magic.mgc"
     ],
     "targets": [
       "linux",

--- a/src/utils.js
+++ b/src/utils.js
@@ -27,8 +27,14 @@ const exec = async (command) => {
 
 const mimeType = async (opts) => {
   const { path, buffer } = opts;
-  FileMagic.magicFile = PATH.join(__dirname, '../assets/magic.mgc');
+  let magicFile = PATH.join(__dirname, '../assets/magic.mgc');
+  if (!fs.existsSync(magicFile))
+    magicFile = PATH.join(
+      __dirname,
+      '../node_modules/@npcz/magic/dist/magic.mgc'
+    );
 
+  FileMagic.magicFile = magicFile;
   FileMagic.defaulFlags = MagicFlags.MAGIC_PRESERVE_ATIME;
   const fileMagic = await FileMagic.getInstance();
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -27,11 +27,8 @@ const exec = async (command) => {
 
 const mimeType = async (opts) => {
   const { path, buffer } = opts;
-  FileMagic.magicFile = PATH.join(
-    __dirname,
-    '..',
-    'node_modules/@npcz/magic/dist/magic.mgc'
-  );
+  FileMagic.magicFile = PATH.join(__dirname, '../assets/magic.mgc');
+
   FileMagic.defaulFlags = MagicFlags.MAGIC_PRESERVE_ATIME;
   const fileMagic = await FileMagic.getInstance();
 


### PR DESCRIPTION
Happens that babel is altering  `magic.mgc` making impossible to just keep the mgc file in the `node_modules` dir.

- closes #898 