### PR TITLE
feat: add auto-merge feature for gitlab

### DIFF
--- a/bin/cml/pr.js
+++ b/bin/cml/pr.js
@@ -19,6 +19,11 @@ exports.builder = (yargs) =>
         type: 'boolean',
         description: 'Output in markdown format [](url).'
       },
+      autoMerge: {
+        type: 'boolean',
+        description:
+          'If enabled, PR/MR will be marked for automatic merging (only works on GitLab).'
+      },
       remote: {
         type: 'string',
         default: GIT_REMOTE,

--- a/src/cml.js
+++ b/src/cml.js
@@ -340,7 +340,8 @@ class CML {
     const {
       remote = GIT_REMOTE,
       globs = ['dvc.lock', '.gitignore'],
-      md
+      md,
+      autoMerge
     } = opts;
 
     await this.ci(opts);
@@ -405,7 +406,8 @@ Automated commits for ${this.repo}/commit/${sha} created by CML.
       source,
       target,
       title,
-      description
+      description,
+      autoMerge
     });
 
     return renderPr(url);


### PR DESCRIPTION
CML is a great tool! We're using it to automatically pull in new data into our repository daily. Currently, we're reviewing + merging every PR manually. We'd like to automate this, and would like to use Gitlab's auto-merge feature to do so. This PR is a first iteration on supporting this. We'll test internally, and if it works, possibly extend the feature to the GitHub driver.