### PR TITLE
Bump CUDA to 11.2.1 on container images

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -141,7 +141,7 @@ jobs:
           - base: 1
             ubuntu: 20.04
             python: 3.8
-            cuda: 11.0.3
+            cuda: 11.2.1
             cudnn: 8
           - latest: true # update the values below after introducing a new major version
             base: 1


### PR DESCRIPTION
They follow semantic versioning, right? 🤔  Closes #766; I haven't performed any kind of [manual] regression test yet.