### PR TITLE
Add support for Bitbucket native uploads 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,7 +11,7 @@ module.exports = {
     SharedArrayBuffer: 'readonly'
   },
   parserOptions: {
-    ecmaVersion: 2018
+    ecmaVersion: 2020
   },
   ignorePatterns: ['assets/', 'dist/', 'node_modules/'],
   rules: {

--- a/src/drivers/bitbucket_cloud.js
+++ b/src/drivers/bitbucket_cloud.js
@@ -381,7 +381,7 @@ class BitbucketCloud {
       // `{"error": "Error message"}`, apart from plain text responses like `Bad Request`.
       const error =
         responseBody.error.message || responseBody.error || responseBody;
-      throw new Error(response.statusText + (error ? ' ' + error : ''));
+      throw new Error(`${response.statusText} ${error}`.trim());
     }
 
     return responseBody;

--- a/src/drivers/bitbucket_cloud.js
+++ b/src/drivers/bitbucket_cloud.js
@@ -1,10 +1,15 @@
+const crypto = require('crypto');
 const fetch = require('node-fetch');
 const winston = require('winston');
 const { URL } = require('url');
+const FormData = require('form-data');
 const ProxyAgent = require('proxy-agent');
+
+const { fetchUploadData } = require('../utils');
 
 const { BITBUCKET_COMMIT, BITBUCKET_BRANCH, BITBUCKET_PIPELINE_UUID } =
   process.env;
+
 class BitbucketCloud {
   constructor(opts = {}) {
     const { repo, token } = opts;
@@ -87,7 +92,29 @@ class BitbucketCloud {
   }
 
   async upload(opts = {}) {
-    throw new Error('Bitbucket Cloud does not support upload!');
+    const { projectPath } = this;
+    const { size, mime, data } = await fetchUploadData(opts);
+
+    const chunks = [];
+    for await (const chunk of data) chunks.push(chunk);
+    const buffer = Buffer.concat(chunks);
+
+    const filename = `cml-${crypto
+      .createHash('sha256')
+      .update(buffer)
+      .digest('hex')}`;
+    const body = new FormData();
+    body.append('files', buffer, { filename });
+
+    const endpoint = `/repositories/${projectPath}/downloads`;
+    await this.request({ endpoint, method: 'POST', body });
+    return {
+      uri: `https://bitbucket.org/${decodeURIComponent(
+        projectPath
+      )}/downloads/${filename}`,
+      mime,
+      size
+    };
   }
 
   async runnerToken() {
@@ -329,10 +356,10 @@ class BitbucketCloud {
 
     if (!(url || endpoint))
       throw new Error('Bitbucket Cloud API endpoint not found');
-    const headers = {
-      'Content-Type': 'application/json',
-      Authorization: 'Basic ' + `${token}`
-    };
+
+    const headers = { Authorization: `Basic ${token}` };
+    if (body.constructor !== FormData)
+      headers['Content-Type'] = 'application/json';
 
     const requestUrl = url || `${api}${endpoint}`;
     winston.debug(`${method} ${requestUrl}`);
@@ -344,20 +371,20 @@ class BitbucketCloud {
       agent: new ProxyAgent()
     });
 
-    if (response.status > 300) {
-      try {
-        const json = await response.json();
-        winston.debug(json);
-        // Attempt to get additional context. We have observed two different error schemas
-        // from BitBucket API responses: `{"error": {"message": "Error message"}}` and
-        // `{"error": "Error message"}`.
-        throw new Error(json.error.message || json.error);
-      } catch (err) {
-        throw new Error(`${response.statusText} ${err.message}`);
-      }
+    const responseBody = response.headers.get('Content-Type').includes('json')
+      ? await response.json()
+      : await response.text();
+
+    if (!response.ok) {
+      // Attempt to get additional context. We have observed two different error schemas
+      // from BitBucket API responses: `{"error": {"message": "Error message"}}` and
+      // `{"error": "Error message"}`, apart from plain text responses like `Bad Request`.
+      const error =
+        responseBody.error.message || responseBody.error || responseBody;
+      throw new Error(response.statusText + (error ? ' ' + error : ''));
     }
 
-    return await response.json();
+    return responseBody;
   }
 }
 

--- a/src/drivers/bitbucket_cloud.js
+++ b/src/drivers/bitbucket_cloud.js
@@ -380,7 +380,7 @@ class BitbucketCloud {
       // from BitBucket API responses: `{"error": {"message": "Error message"}}` and
       // `{"error": "Error message"}`, apart from plain text responses like `Bad Request`.
       const error =
-        responseBody.error.message || responseBody.error || responseBody;
+        responseBody?.error?.message || responseBody?.error || responseBody;
       throw new Error(`${response.statusText} ${error}`.trim());
     }
 

--- a/src/drivers/bitbucket_cloud.test.js
+++ b/src/drivers/bitbucket_cloud.test.js
@@ -29,9 +29,9 @@ describe('Non Enviromental tests', () => {
 
   test('Publish', async () => {
     const path = `${__dirname}/../../assets/logo.png`;
-    await expect(client.upload({ path })).rejects.toThrow(
-      'Bitbucket Cloud does not support upload!'
-    );
+    const { uri } = await client.upload({ path });
+
+    expect(uri).not.toBeUndefined();
   });
 
   test('Runner token', async () => {


### PR DESCRIPTION
[Bitbucket Downloads](https://support.atlassian.com/bitbucket-cloud/docs/deploy-build-artifacts-to-bitbucket-downloads) is more similar to [GitHub Releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases) than to [GitLab Uploads](https://docs.gitlab.com/ee/administration/uploads.html). Not sure if it's “the right way” of storing report images.

> _[Tokens] must have write or admin access [sic]_

---

_Refactored from an unmerged commit I wrote on 2021-09-25 (#930)_