### PR TITLE
Paginate octokit requests

### DIFF
--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -625,24 +625,33 @@ class Github {
     let { status = 'queued' } = opts;
     if (status === 'running') status = 'in_progress';
 
-    const workflowRuns = await octokitClient.paginate(octokitClient.actions.listWorkflowRunsForRepo, {
-      owner,
-      repo,
-      status
-    });
-    
-    winston.warn("Length of workflowRuns: ${workflowRuns.length}");
+    const workflowRuns = await octokitClient.paginate(
+      octokitClient.actions.listWorkflowRunsForRepo,
+      {
+        owner,
+        repo,
+        status
+      }
+    );
+
+    winston.warn(`Length of workflowRuns: ${workflowRuns.length}`);
 
     let runJobs = await Promise.all(
-      workflowRuns.map(async (run) => await octokitClient.paginate(octokitClient.actions.listJobsForWorkflowRun, {
-          owner,
-          repo,
-          run_id: run.id,
-          status
-        }))
+      workflowRuns.map(
+        async (run) =>
+          await octokitClient.paginate(
+            octokitClient.actions.listJobsForWorkflowRun,
+            {
+              owner,
+              repo,
+              run_id: run.id,
+              status
+            }
+          )
+      )
     );
-    
-    winston.warn("Length of runJobs: ${runJobs.length}");
+
+    winston.warn(`Length of runJobs: ${runJobs.length}`);
 
     runJobs = [].concat.apply([], runJobs).map((job) => {
       const { id, started_at: date, run_id: runId, runner_id: runnerId } = job;

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -638,13 +638,13 @@ class Github {
 
     let runJobs = await Promise.all(
       workflowRuns.map(
-        async (run) =>
+        async ({ id }) =>
           await octokitClient.paginate(
             octokitClient.actions.listJobsForWorkflowRun,
             {
               owner,
               repo,
-              run_id: run.id,
+              run_id: id,
               status
             }
           )

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -630,8 +630,6 @@ class Github {
       { owner, repo, status }
     );
 
-    winston.warn(`Length of workflowRuns: ${workflowRuns.length}`);
-
     let runJobs = await Promise.all(
       workflowRuns.map(
         async ({ id }) =>
@@ -641,8 +639,6 @@ class Github {
           )
       )
     );
-
-    winston.warn(`Length of runJobs: ${runJobs.length}`);
 
     runJobs = [].concat.apply([], runJobs).map((job) => {
       const { id, started_at: date, run_id: runId, runner_id: runnerId } = job;

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -630,6 +630,8 @@ class Github {
       repo,
       status
     });
+    
+    winston.warn("Length of workflowRuns: ${workflowRuns.length}");
 
     let runJobs = await Promise.all(
       workflowRuns.map(async (run) => await octokitClient.paginate(octokitClient.actions.listJobsForWorkflowRun, {
@@ -639,6 +641,8 @@ class Github {
           status
         }))
     );
+    
+    winston.warn("Length of runJobs: ${runJobs.length}");
 
     runJobs = [].concat.apply([], runJobs).map((job) => {
       const { id, started_at: date, run_id: runId, runner_id: runnerId } = job;

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -620,32 +620,24 @@ class Github {
   async job(opts = {}) {
     const { time, runnerId } = opts;
     const { owner, repo } = ownerRepo({ uri: this.repo });
-    const { actions } = octokit(this.token, this.repo);
+    const octokitClient = octokit(this.token, this.repo);
 
     let { status = 'queued' } = opts;
     if (status === 'running') status = 'in_progress';
 
-    const {
-      data: { workflow_runs: workflowRuns }
-    } = await actions.listWorkflowRunsForRepo({
+    const workflowRuns = await octokitClient.paginate(octokitClient.actions.listWorkflowRunsForRepo, {
       owner,
       repo,
       status
     });
 
     let runJobs = await Promise.all(
-      workflowRuns.map(async (run) => {
-        const {
-          data: { jobs }
-        } = await actions.listJobsForWorkflowRun({
+      workflowRuns.map(async (run) => await octokitClient.paginate(octokitClient.actions.listJobsForWorkflowRun, {
           owner,
           repo,
           run_id: run.id,
           status
-        });
-
-        return jobs;
-      })
+        }))
     );
 
     runJobs = [].concat.apply([], runJobs).map((job) => {

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -627,11 +627,7 @@ class Github {
 
     const workflowRuns = await octokitClient.paginate(
       octokitClient.actions.listWorkflowRunsForRepo,
-      {
-        owner,
-        repo,
-        status
-      }
+      { owner, repo, status }
     );
 
     winston.warn(`Length of workflowRuns: ${workflowRuns.length}`);
@@ -641,12 +637,7 @@ class Github {
         async ({ id }) =>
           await octokitClient.paginate(
             octokitClient.actions.listJobsForWorkflowRun,
-            {
-              owner,
-              repo,
-              run_id: id,
-              status
-            }
+            { owner, repo, run_id: id, status }
           )
       )
     );


### PR DESCRIPTION
Does **not** solve #923, but definitely worth meeging: the GitHub REST API limits responses to the [30 first items](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#pagination) by default.