### PR TITLE
Fix GitHub `actions.listWorkflowRunsForRepo` status filtering

### DIFF
--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -632,9 +632,24 @@ class Github {
       repo
     });
 
+    const {
+      data: { workflow_runs: workflowRunsFilter }
+    } = await actions.listWorkflowRunsForRepo({
+      owner,
+      repo,
+      status
+    });
+
     winston.warn(
       'Statuses from the last 30 items: ' +
         workflowRunsAll.map(({ status, id }) => JSON.stringify({ status, id }))
+    );
+    winston.warn(
+      status +
+        ' statuses from the last 30 items: ' +
+        workflowRunsFilter.map(({ status, id }) =>
+          JSON.stringify({ status, id })
+        )
     );
 
     const {

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -634,7 +634,7 @@ class Github {
 
     winston.warn(
       'Statuses from the last 30 items: ' +
-        workflowRunsAll.map(({ status }) => status)
+        workflowRunsAll.map(({ status, id }) => JSON.stringify({ status, id }))
     );
 
     const {

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -626,6 +626,18 @@ class Github {
     if (status === 'running') status = 'in_progress';
 
     const {
+      data: { workflow_runs: workflowRunsAll }
+    } = await actions.listWorkflowRunsForRepo({
+      owner,
+      repo
+    });
+
+    winston.warn(
+      'Statuses from the last 30 items: ' +
+        workflowRunsAll.map(({ status }) => status)
+    );
+
+    const {
       data: { workflow_runs: workflowRuns }
     } = await actions.listWorkflowRunsForRepo({
       owner,


### PR DESCRIPTION
This pull request **does** close #923, but filtering is done on the client side 