### PR TITLE
Build `pkg` standalone binaries for more platforms

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -107,8 +107,8 @@ jobs:
           for cmd in '' runner publish pr; do
             build/cml-linux-x64 $cmd --version
           done
-          cp cml-linux-x64 cml-linux
-          cp cml-macos-x64 cml-macos
+          cp build/cml-linux{-x64,}
+          cp build/cml-macos{-x64,}
       - uses: softprops/action-gh-release@v1
         if: github.event_name == 'push'
         with:

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -97,25 +97,6 @@ jobs:
           sudo apt install --yes libplist-dev
           git clone --branch v2.1.5 git://git.saurik.com/ldid.git 
           sudo g++ -pipe -o /usr/bin/ldid ldid.cpp -I. -x c lookup2.c sha1.h -lplist -lcrypto
-      - name: build
-        run: |
-          cp node_modules/@npcz/magic/dist/magic.mgc assets/magic.mgc
-          npx --yes pkg --no-bytecode --public-packages "*" --public package.json
-          rm assets/magic.mgc
-          for cmd in '' runner publish pr; do
-            build/cml-linux $cmd --version
-          done
-  release:
-    if: github.event_name == 'push'
-    needs: packages
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: install ldid
-        run: |
-          sudo apt install --yes libplist-dev
-          git clone --branch v2.1.5 git://git.saurik.com/ldid.git 
-          sudo g++ -pipe -o /usr/bin/ldid ldid.cpp -I. -x c lookup2.c sha1.h -lplist -lcrypto
       - id: build
         name: build
         run: |
@@ -124,7 +105,13 @@ jobs:
           cp node_modules/@npcz/magic/dist/magic.mgc assets/magic.mgc
           npx --yes pkg --no-bytecode --public-packages "*" --public package.json
           rm assets/magic.mgc
+          for cmd in '' runner publish pr; do
+            build/cml-linux-x64 $cmd --version
+          done
+          cp cml-linux-x64 cml-linux
+          cp cml-macos-x64 cml-macos
       - uses: softprops/action-gh-release@v1
+        if: github.event_name == 'push'
         with:
           name: CML ${{ steps.build.outputs.tag }}
           draft: true
@@ -136,8 +123,10 @@ jobs:
             build/cml-linuxstatic-arm64
             build/cml-linuxstatic-x64
             build/cml-linux-x64
+            build/cml-linux
             build/cml-macos-arm64
             build/cml-macos-x64
+            build/cml-macos
             build/cml-win-arm64.exe
             build/cml-win-x64.exe
         env:

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -122,6 +122,7 @@ jobs:
           files: |
             build/cml-linux
             build/cml-macos
+            build/cml-windows.exe
         env:
           GITHUB_TOKEN: ${{ secrets.TEST_GITHUB_TOKEN }}
   images:

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -92,10 +92,15 @@ jobs:
           --dry-run' }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: install ldid
+        run: |
+          sudo apt install --yes libplist-dev
+          git clone --branch v2.1.5 git://git.saurik.com/ldid.git 
+          sudo g++ -pipe -o /usr/bin/ldid ldid.cpp -I. -x c lookup2.c sha1.h -lplist -lcrypto
       - name: build
         run: |
           cp node_modules/@npcz/magic/dist/magic.mgc assets/magic.mgc
-          npx --yes pkg package.json
+          npx --yes pkg --no-bytecode --public-packages "*" --public package.json
           rm assets/magic.mgc
           for cmd in '' runner publish pr; do
             build/cml-linux $cmd --version
@@ -106,13 +111,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: install ldid
+        run: |
+          sudo apt install --yes libplist-dev
+          git clone --branch v2.1.5 git://git.saurik.com/ldid.git 
+          sudo g++ -pipe -o /usr/bin/ldid ldid.cpp -I. -x c lookup2.c sha1.h -lplist -lcrypto
       - id: build
         name: build
         run: |
           echo ::set-output name=tag::${GITHUB_REF#refs/tags/}
           npm install
           cp node_modules/@npcz/magic/dist/magic.mgc assets/magic.mgc
-          npx --yes pkg package.json
+          npx --yes pkg --no-bytecode --public-packages "*" --public package.json
           rm assets/magic.mgc
       - uses: softprops/action-gh-release@v1
         with:
@@ -120,9 +130,16 @@ jobs:
           draft: true
           generate_release_notes: true
           files: |
-            build/cml-linux
-            build/cml-macos
-            build/cml-windows.exe
+            build/cml-alpine-arm64
+            build/cml-alpine-x64
+            build/cml-linux-arm64
+            build/cml-linuxstatic-arm64
+            build/cml-linuxstatic-x64
+            build/cml-linux-x64
+            build/cml-macos-arm64
+            build/cml-macos-x64
+            build/cml-win-arm64.exe
+            build/cml-win-x64.exe
         env:
           GITHUB_TOKEN: ${{ secrets.TEST_GITHUB_TOKEN }}
   images:

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -96,7 +96,7 @@ jobs:
         run: |
           sudo apt install --yes libplist-dev
           git clone --branch v2.1.5 git://git.saurik.com/ldid.git 
-          sudo g++ -pipe -o /usr/bin/ldid ldid.cpp -I. -x c lookup2.c sha1.h -lplist -lcrypto
+          sudo g++ -pipe -o /usr/bin/ldid ldid/ldid.cpp -I. -x c ldid/{lookup2.c,sha1.h} -lplist -lcrypto
       - id: build
         name: build
         run: |

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -101,7 +101,6 @@ jobs:
         name: build
         run: |
           echo ::set-output name=tag::${GITHUB_REF#refs/tags/}
-          npm install
           cp node_modules/@npcz/magic/dist/magic.mgc assets/magic.mgc
           npx --yes pkg --no-bytecode --public-packages "*" --public package.json
           rm assets/magic.mgc

--- a/package.json
+++ b/package.json
@@ -128,8 +128,14 @@
       "assets/magic.mgc"
     ],
     "targets": [
-      "linux",
-      "macos"
+      "node16-alpine-arm64",
+      "node16-alpine-x64",
+      "node16-macos-arm64",
+      "node16-macos-x64"
+      "node16-linux-arm64",
+      "node16-linux-x64",
+      "node16-win-arm64",
+      "node16-win-x64",
     ],
     "outputPath": "build"
   }

--- a/package.json
+++ b/package.json
@@ -131,11 +131,13 @@
       "node16-alpine-arm64",
       "node16-alpine-x64",
       "node16-macos-arm64",
-      "node16-macos-x64"
+      "node16-macos-x64",
       "node16-linux-arm64",
       "node16-linux-x64",
+      "node16-linuxstatic-arm64",
+      "node16-linuxstatic-x64",
       "node16-win-arm64",
-      "node16-win-x64",
+      "node16-win-x64"
     ],
     "outputPath": "build"
   }


### PR DESCRIPTION
Required for https://github.com/iterative/setup-cml/issues/57 and https://github.com/iterative/setup-cml/pull/60#issuecomment-1097229584. Bring sanity back to artifact names without introducing any breaking change. 🎉 

Tests are broken because they run on `pull_request_target` with the old workflow