### PR TITLE
cml ci: unshallow repos

### DIFF
--- a/src/cml.js
+++ b/src/cml.js
@@ -1,8 +1,10 @@
 const { execSync } = require('child_process');
+const fs = require('fs').promises;
 const gitUrlParse = require('git-url-parse');
 const stripAuth = require('strip-url-auth');
 const globby = require('globby');
 const git = require('simple-git')('./');
+const path = require('path');
 
 const winston = require('winston');
 
@@ -335,6 +337,13 @@ class CML {
     const driver = getDriver(this);
     const command = await driver.updateGitConfig({ userName, userEmail });
     await exec(command);
+    const gitDir = execSync(`git rev-parse --git-dir`).toString('utf8');
+    try {
+      fs.accessSync(path.join(gitDir, 'shallow'))
+      await exec('git fetch --unshallow');
+    } catch (err) {
+      // repo not shallow
+    }
     await exec('git fetch --all');
   }
 


### PR DESCRIPTION
Docs for `cml ci` state

> Prepares Git repository for CML operations (setting Git user.name & user.email, **unshallow clone** and undo CI oddities such as origin URL formatting and HTTP remote proxies).

but `cml ci` does not currently unshallow the clone. It just does `fetch --all`, which fetches all remote branches, but does not actually modify fetch depth of any of those branches. So in github/gitlab the repo will just have a bunch of shallow branches with depth=1 rather than a single ref/commit with depth=1.

Assuming that unshallowing all clones by default is the intended behavior (which I'm not sure is actually desired, since it will have a significant performance impact in large git repos), what `cml ci` needs to be doing is something like

```bash
# check if the repo is shallow
if [ -f `git rev-parse --git-dir`/shallow ]; then
    git fetch --unshallow
fi
git fetch --all
```
Note that the check for `GIT_DIR/shallow` is required since repeated `git fetch --unshallow` calls will fail if the repo is not actually shallow, which would also cause repeated `cml ci` calls to fail

(Also, I have not tested the changes in this PR, and I'm not a node/js dev so there's probably a better way of accomplishing this in node)