### PR TITLE
ci: add `--unshallow`

### DIFF
--- a/bin/cml/ci.js
+++ b/bin/cml/ci.js
@@ -14,6 +14,11 @@ exports.handler = async (opts) => {
 exports.builder = (yargs) =>
   yargs.env('CML_CI').options(
     kebabcaseKeys({
+      unshallow: {
+        type: 'boolean',
+        description:
+          'Fetch as much as possible, converting a shallow repository to a complete one.'
+      },
       userEmail: {
         type: 'string',
         default: GIT_USER_EMAIL,

--- a/bin/cml/ci.test.js
+++ b/bin/cml/ci.test.js
@@ -14,6 +14,8 @@ describe('CML e2e', () => {
         --version     Show version number                                    [boolean]
         --log         Maximum log level
                 [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
+        --unshallow   Fetch as much as possible, converting a shallow repository to a
+                      complete one.                                          [boolean]
         --user-email  Set Git user email.    [string] [default: \\"olivaw@iterative.ai\\"]
         --user-name   Set Git user name.             [string] [default: \\"Olivaw[bot]\\"]
         --repo        Set repository to be used. If unspecified, inferred from the

--- a/src/cml.js
+++ b/src/cml.js
@@ -339,9 +339,9 @@ class CML {
     const driver = getDriver(this);
     await exec(await driver.updateGitConfig({ userName, userEmail }));
     if (unshallow) {
-        if ((await exec('git rev-parse --is-shallow-repository')) === 'true') {
-            await exec('git fetch --unshallow');
-        }
+      if ((await exec('git rev-parse --is-shallow-repository')) === 'true') {
+        await exec('git fetch --unshallow');
+      }
     }
     await exec('git fetch --all');
   }

--- a/src/cml.js
+++ b/src/cml.js
@@ -1,6 +1,4 @@
 const { execSync } = require('child_process');
-const PATH = require('path');
-const fse = require('fs-extra');
 const gitUrlParse = require('git-url-parse');
 const stripAuth = require('strip-url-auth');
 const globby = require('globby');
@@ -339,14 +337,9 @@ class CML {
     } = opts;
 
     const driver = getDriver(this);
-    const command = await driver.updateGitConfig({ userName, userEmail });
-    await exec(command);
-    if (unshallow) {
-      const gitdir = await exec('git rev-parse --git-dir');
-      if (await fse.pathExists(PATH.join(gitdir, 'shallow'))) {
-        await exec('git fetch --unshallow');
-      }
-    }
+    const shallow = await exec('git rev-parse --is-shallow-repository');
+    if (unshallow && shallow === 'true') await exec('git fetch --unshallow');
+    await exec(await driver.updateGitConfig({ userName, userEmail }));
     await exec('git fetch --all');
   }
 

--- a/src/cml.js
+++ b/src/cml.js
@@ -1,4 +1,5 @@
 const { execSync } = require('child_process');
+const PATH = require('path');
 const fse = require('fs-extra');
 const gitUrlParse = require('git-url-parse');
 const stripAuth = require('strip-url-auth');
@@ -342,7 +343,7 @@ class CML {
     await exec(command);
     if (unshallow) {
       const gitdir = await exec('git rev-parse --git-dir');
-      if (await fse.pathExists(gitdir + '/shallow')) {
+      if (await fse.pathExists(PATH.join(gitdir, 'shallow'))) {
         await exec('git fetch --unshallow');
       }
     }

--- a/src/cml.js
+++ b/src/cml.js
@@ -337,9 +337,12 @@ class CML {
     } = opts;
 
     const driver = getDriver(this);
-    const shallow = await exec('git rev-parse --is-shallow-repository');
-    if (unshallow && shallow === 'true') await exec('git fetch --unshallow');
     await exec(await driver.updateGitConfig({ userName, userEmail }));
+    if (unshallow) {
+        if ((await exec('git rev-parse --is-shallow-repository')) === 'true') {
+            await exec('git fetch --unshallow');
+        }
+    }
     await exec('git fetch --all');
   }
 


### PR DESCRIPTION
- useful cross-CI substitute for GHA `checkout.with.fetch-depth: 0`
- probably shouldn't be the default due to
  + not needed in all cases (only needed if full history is required, e.g. [some `dvc exp run` cases](https://github.com/iterative/dvc/issues/7547))
  + performance hit in large repos

Original idea by @pmrowla 

/CC @dberenbaum @alex000kim