### PR TITLE
Revert conditional chaining

### DIFF
--- a/src/drivers/bitbucket_cloud.js
+++ b/src/drivers/bitbucket_cloud.js
@@ -379,14 +379,8 @@ class BitbucketCloud {
       // Attempt to get additional context. We have observed two different error schemas
       // from BitBucket API responses: `{"error": {"message": "Error message"}}` and
       // `{"error": "Error message"}`, apart from plain text responses like `Bad Request`.
-      const error = responseBody // FIXME: use conditional chaining when dropping node<16
-        ? responseBody.error
-          ? responseBody.error.message
-            ? responseBody.error.message
-            : responseBody.error
-          : responseBody
-        : responseBody;
-      throw new Error(`${response.statusText} ${error}`.trim());
+const { error } = responseBody.error ?  responseBody : { error: responseBody }
+throw new Error(`${response.statusText} ${error.message || error}`.trim());
     }
 
     return responseBody;

--- a/src/drivers/bitbucket_cloud.js
+++ b/src/drivers/bitbucket_cloud.js
@@ -379,8 +379,13 @@ class BitbucketCloud {
       // Attempt to get additional context. We have observed two different error schemas
       // from BitBucket API responses: `{"error": {"message": "Error message"}}` and
       // `{"error": "Error message"}`, apart from plain text responses like `Bad Request`.
-      const error =
-        responseBody?.error?.message || responseBody?.error || responseBody;
+      const error = responseBody // FIXME: use conditional chaining when dropping node<16
+        ? responseBody.error
+          ? responseBody.error.message
+            ? responseBody.error.message
+            : responseBody.error
+          : responseBody
+        : responseBody;
       throw new Error(`${response.statusText} ${error}`.trim());
     }
 

--- a/src/drivers/bitbucket_cloud.js
+++ b/src/drivers/bitbucket_cloud.js
@@ -379,8 +379,12 @@ class BitbucketCloud {
       // Attempt to get additional context. We have observed two different error schemas
       // from BitBucket API responses: `{"error": {"message": "Error message"}}` and
       // `{"error": "Error message"}`, apart from plain text responses like `Bad Request`.
-const { error } = responseBody.error ?  responseBody : { error: responseBody }
-throw new Error(`${response.statusText} ${error.message || error}`.trim());
+      const { error } = responseBody.error
+        ? responseBody
+        : { error: responseBody };
+      throw new Error(
+        `${response.statusText} ${error.message || error}`.trim()
+      );
     }
 
     return responseBody;


### PR DESCRIPTION
Fixes #960 & closes #965. Is ~ugly as a sin~ moderately ugly, thanks to @DavidGOrtega's suggestion.

### Before
```javascript
const error =
        responseBody?.error?.message || responseBody?.error || responseBody;
throw new Error(`${response.statusText} ${error}`.trim());
```
### After
```javascript
const { error } = responseBody.error ?  responseBody : { error: responseBody }
throw new Error(`${response.statusText} ${error.message || error}`.trim());
```
