### PR TITLE
Default to `HEAD` on `send-comment --commit-sha`

### DIFF
--- a/bin/cml/send-comment.js
+++ b/bin/cml/send-comment.js
@@ -24,7 +24,8 @@ exports.builder = (yargs) =>
       commitSha: {
         type: 'string',
         alias: 'head-sha',
-        description: 'Commit SHA linked to this comment. Defaults to HEAD.'
+        default: 'HEAD',
+        description: 'Commit SHA linked to this comment'
       },
       update: {
         type: 'boolean',

--- a/bin/cml/send-comment.test.js
+++ b/bin/cml/send-comment.test.js
@@ -14,31 +14,31 @@ describe('Comment integration tests', () => {
     const output = await exec(`node ./bin/cml.js send-comment --help`);
 
     expect(output).toMatchInlineSnapshot(`
-"cml.js send-comment <markdown file>
+      "cml.js send-comment <markdown file>
 
-Comment on a commit
+      Comment on a commit
 
-Options:
-  --help                    Show help                                  [boolean]
-  --version                 Show version number                        [boolean]
-  --log                     Maximum log level
-          [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
-  --pr                      Post to an existing PR/MR associated with the
-                            specified commit                           [boolean]
-  --commit-sha, --head-sha  Commit SHA linked to this comment. Defaults to HEAD.
-                                                                        [string]
-  --update                  Update the last CML comment (if any) instead of
-                            creating a new one                         [boolean]
-  --rm-watermark            Avoid watermark. CML needs a watermark to be able to
-                            distinguish CML reports from other comments in order
-                            to provide extra functionality.            [boolean]
-  --repo                    Specifies the repo to be used. If not specified is
-                            extracted from the CI ENV.                  [string]
-  --token                   Personal access token to be used. If not specified
-                            is extracted from ENV REPO_TOKEN.           [string]
-  --driver                  If not specify it infers it from the ENV.
-                             [string] [choices: \\"github\\", \\"gitlab\\", \\"bitbucket\\"]"
-`);
+      Options:
+        --help                    Show help                                  [boolean]
+        --version                 Show version number                        [boolean]
+        --log                     Maximum log level
+                [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
+        --pr                      Post to an existing PR/MR associated with the
+                                  specified commit                           [boolean]
+        --commit-sha, --head-sha  Commit SHA linked to this comment
+                                                            [string] [default: \\"HEAD\\"]
+        --update                  Update the last CML comment (if any) instead of
+                                  creating a new one                         [boolean]
+        --rm-watermark            Avoid watermark. CML needs a watermark to be able to
+                                  distinguish CML reports from other comments in order
+                                  to provide extra functionality.            [boolean]
+        --repo                    Specifies the repo to be used. If not specified is
+                                  extracted from the CI ENV.                  [string]
+        --token                   Personal access token to be used. If not specified
+                                  is extracted from ENV REPO_TOKEN.           [string]
+        --driver                  If not specify it infers it from the ENV.
+                                   [string] [choices: \\"github\\", \\"gitlab\\", \\"bitbucket\\"]"
+    `);
   });
 
   test('cml send-comment to specific repo', async () => {


### PR DESCRIPTION
> [_`--commit-sha=<rev>`: Git revision linked to this comment [default: HEAD]._](https://cml.dev/doc/ref/send-comment#options)

Closes #991. Documentation is a lie! It defaulted to `triggerSha` which doesn't get updated when `cml pr` runs.

https://github.com/iterative/cml/blob/352fba44faf2eb69d81d4cb5f60220f60f5f8e49/src/cml.js#L143