### PR TITLE
Fix NVIDIA APT GPG keys

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ SHELL ["/bin/bash", "-c"]
 # FIX NVIDIA APT GPG KEYS (https://github.com/NVIDIA/cuda-repo-management/issues/1#issuecomment-1111490201) 🤬
 RUN apt-key del 7fa2af80 \
  && curl -LO https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-keyring_1.0-1_all.deb \
- && dpkg -i cuda-keyring_1.0-1_all.deb \
+ && dpkg -i cuda-keyring_1.0-1_all.deb
 
 # INSTALL CORE DEPENDENCIES
 RUN apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,17 @@ RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90assumeyes
 SHELL ["/bin/bash", "-c"]
 
 # FIX NVIDIA APT GPG KEYS (https://github.com/NVIDIA/cuda-repo-management/issues/1#issuecomment-1111490201) 🤬
-RUN apt-get update \
+RUN for list in cuda nvidia-ml; do mv /etc/apt/sources.list.d/cuda.list{,.backup}; done
+ && apt-get update \
  && apt-get install --yes gpg \
  && apt-key del 7fa2af80 \
  && apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/3bf863cc.pub \
+ && apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1404/x86_64/7fa2af80.pub \
+ && apt-get purge --yes gpg \
  && apt-get clean \
- && rm --recursive --force /var/lib/apt/lists/*
+ && rm --recursive --force /var/lib/apt/lists/* \
+ && for list in cuda nvidia-ml; do mv /etc/apt/sources.list.d/cuda.list{.backup,}; done
+ 
  
 # INSTALL CORE DEPENDENCIES
 RUN apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ SHELL ["/bin/bash", "-c"]
 RUN apt-get update \
  && apt-get install --yes gpg \
  && apt-key del 7fa2af80 \
- && apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/3bf863cc.pub
+ && apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/3bf863cc.pub \
  && apt-get clean \
  && rm --recursive --force /var/lib/apt/lists/*
  

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@ RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90assumeyes
 # CONFIGURE SHELL
 SHELL ["/bin/bash", "-c"]
 
+# FIX NVIDIA APT GPG KEYS (https://github.com/NVIDIA/cuda-repo-management/issues/1#issuecomment-1111490201) 🤬
+RUN apt-key del 7fa2af80
+RUN apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/3bf863cc.pub
+
 # INSTALL CORE DEPENDENCIES
 RUN apt-get update \
  && apt-get install --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90assumeyes
 SHELL ["/bin/bash", "-c"]
 
 # FIX NVIDIA APT GPG KEYS (https://github.com/NVIDIA/cuda-repo-management/issues/1#issuecomment-1111490201) 🤬
-RUN grep --invert-match nvidia <<< ${BASE_IMAGE} \
- || for list in cuda nvidia-ml; do mv /etc/apt/sources.list.d/cuda.list{,.backup}; done \
+RUN grep nvidia <<< ${BASE_IMAGE} \
+ && for list in cuda nvidia-ml; do mv /etc/apt/sources.list.d/cuda.list{,.backup}; done \
  && apt-get update \
  && apt-get install --yes gpg \
  && apt-key del 7fa2af80 \
@@ -21,7 +21,8 @@ RUN grep --invert-match nvidia <<< ${BASE_IMAGE} \
  && apt-get purge --yes gpg \
  && apt-get clean \
  && rm --recursive --force /var/lib/apt/lists/* \
- && for list in cuda nvidia-ml; do mv /etc/apt/sources.list.d/cuda.list{.backup,}; done
+ && for list in cuda nvidia-ml; do mv /etc/apt/sources.list.d/cuda.list{.backup,}; done \
+ || true
 
 # INSTALL CORE DEPENDENCIES
 RUN apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,7 @@ RUN for list in cuda nvidia-ml; do mv /etc/apt/sources.list.d/cuda.list{,.backup
  && apt-get clean \
  && rm --recursive --force /var/lib/apt/lists/* \
  && for list in cuda nvidia-ml; do mv /etc/apt/sources.list.d/cuda.list{.backup,}; done
- 
- 
+
 # INSTALL CORE DEPENDENCIES
 RUN apt-get update \
  && apt-get install --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,13 @@ RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90assumeyes
 SHELL ["/bin/bash", "-c"]
 
 # FIX NVIDIA APT GPG KEYS (https://github.com/NVIDIA/cuda-repo-management/issues/1#issuecomment-1111490201) 🤬
-RUN apt-key del 7fa2af80 \
- && curl -LO https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-keyring_1.0-1_all.deb \
- && dpkg -i cuda-keyring_1.0-1_all.deb
-
+RUN apt-get update \
+ && apt-get install --yes gpg \
+ && apt-key del 7fa2af80 \
+ && apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/3bf863cc.pub
+ && apt-get clean \
+ && rm --recursive --force /var/lib/apt/lists/*
+ 
 # INSTALL CORE DEPENDENCIES
 RUN apt-get update \
  && apt-get install --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,9 @@ RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90assumeyes
 SHELL ["/bin/bash", "-c"]
 
 # FIX NVIDIA APT GPG KEYS (https://github.com/NVIDIA/cuda-repo-management/issues/1#issuecomment-1111490201) 🤬
-RUN apt-key del 7fa2af80
-RUN apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/3bf863cc.pub
+RUN apt-key del 7fa2af80 \
+ && curl -LO https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-keyring_1.0-1_all.deb \
+ && dpkg -i cuda-keyring_1.0-1_all.deb \
 
 # INSTALL CORE DEPENDENCIES
 RUN apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90assumeyes
 SHELL ["/bin/bash", "-c"]
 
 # FIX NVIDIA APT GPG KEYS (https://github.com/NVIDIA/cuda-repo-management/issues/1#issuecomment-1111490201) 🤬
-RUN for list in cuda nvidia-ml; do mv /etc/apt/sources.list.d/cuda.list{,.backup}; done \
+RUN grep --invert-match nvidia <<< ${BASE_IMAGE} \
+ || for list in cuda nvidia-ml; do mv /etc/apt/sources.list.d/cuda.list{,.backup}; done \
  && apt-get update \
  && apt-get install --yes gpg \
  && apt-key del 7fa2af80 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90assumeyes
 SHELL ["/bin/bash", "-c"]
 
 # FIX NVIDIA APT GPG KEYS (https://github.com/NVIDIA/cuda-repo-management/issues/1#issuecomment-1111490201) 🤬
-RUN for list in cuda nvidia-ml; do mv /etc/apt/sources.list.d/cuda.list{,.backup}; done
+RUN for list in cuda nvidia-ml; do mv /etc/apt/sources.list.d/cuda.list{,.backup}; done \
  && apt-get update \
  && apt-get install --yes gpg \
  && apt-key del 7fa2af80 \


### PR DESCRIPTION
Closes #993; pay no attention to `ubuntu1604` in the key path: it's the same for all the newer versions.