### PR TITLE
Runner faster termination

### DIFF
--- a/bin/cml/runner.js
+++ b/bin/cml/runner.js
@@ -28,8 +28,7 @@ const shutdown = async (opts) => {
     tfResource,
     noRetry,
     reason,
-    destroyDelay,
-    single
+    destroyDelay
   } = opts;
   const tfPath = workdir;
 
@@ -42,13 +41,7 @@ const shutdown = async (opts) => {
       RUNNER && RUNNER.kill('SIGINT');
       winston.info('\tSuccess');
     } catch (err) {
-      if (single) {
-        winston.warn(
-          `\tFailed: Runner in --single mode, might have cleared itself.`
-        );
-      } else {
-        winston.error(`\tFailed: ${err.message}`);
-      }
+      winston.error(`\tFailed: ${err.message}`);
     }
   };
 

--- a/src/cml.js
+++ b/src/cml.js
@@ -340,7 +340,7 @@ class CML {
 
   async unregisterRunner(opts = {}) {
     const { id: runnerId } = (await this.runnerByName(opts)) || {};
-    if (!runnerId) throw new Error(`Runner with id ${runnerId} not found`);
+    if (!runnerId) throw new Error(`Runner not found`);
 
     return await getDriver(this).unregisterRunner({ runnerId, ...opts });
   }

--- a/src/cml.js
+++ b/src/cml.js
@@ -339,7 +339,9 @@ class CML {
   }
 
   async unregisterRunner(opts = {}) {
-    const { id: runnerId } = await this.runnerByName(opts);
+    const { id: runnerId } = (await this.runnerByName(opts)) || {};
+    if (!runnerId) throw new Error(`Runner with id ${runnerId} not found`);
+
     return await getDriver(this).unregisterRunner({ runnerId, ...opts });
   }
 


### PR DESCRIPTION
The intention of this PR is:

 - avoid having to wait X secs prior to destroy in every scenario. Only if it needs to cleanup TF resources
 - Unregister the runner prior to try to kill the underlying CI runner to not accept more jobs.
 - Fixes #990 with a proper message