### PR TITLE
additional `cml pr` options

### DIFF
--- a/bin/cml/pr.js
+++ b/bin/cml/pr.js
@@ -41,11 +41,11 @@ exports.builder = (yargs) =>
       },
       branch: {
         type: 'string',
-        description: 'set Custom branch name for pull request'
+        description: 'Set a custom branch name for pull request.'
       },
       title: {
         type: 'string',
-        description: 'Title of the created pull request'
+        description: 'Title of the created pull request.'
       },
       body: {
         type: 'string',
@@ -55,7 +55,7 @@ exports.builder = (yargs) =>
       message: {
         type: 'string',
         description:
-          'commit message for the new commit used to open the pull request'
+          'The commit message for the new commit used to open the pull request'
       },
       remote: {
         type: 'string',

--- a/bin/cml/pr.js
+++ b/bin/cml/pr.js
@@ -39,6 +39,20 @@ exports.builder = (yargs) =>
         conflicts: ['merge', 'rebase'],
         description: 'Try to squash-merge the pull request upon creation.'
       },
+      title: {
+        type: 'string',
+        description: 'Title of the created pull request'
+      },
+      body: {
+        type: 'string',
+        description:
+          'Description/body of created pull request [string or file]. Ex "My cml pr", "reports/experiment-results.md"'
+      },
+      message: {
+        type: 'string',
+        description:
+          'commit message for the new commit used to open the pull request'
+      },
       remote: {
         type: 'string',
         default: GIT_REMOTE,

--- a/bin/cml/pr.js
+++ b/bin/cml/pr.js
@@ -53,7 +53,7 @@ exports.builder = (yargs) =>
       },
       message: {
         type: 'string',
-        description: 'Commit message'
+        description: 'Commit message.'
       },
       remote: {
         type: 'string',

--- a/bin/cml/pr.js
+++ b/bin/cml/pr.js
@@ -50,7 +50,7 @@ exports.builder = (yargs) =>
       body: {
         type: 'string',
         description:
-          'Description/body of created pull request [string or file]. Ex "My cml pr", "reports/experiment-results.md"'
+          'Body for the created pull request [string or filename].'
       },
       message: {
         type: 'string',

--- a/bin/cml/pr.js
+++ b/bin/cml/pr.js
@@ -41,20 +41,19 @@ exports.builder = (yargs) =>
       },
       branch: {
         type: 'string',
-        description: 'Set a custom branch name for pull request.'
+        description: 'Branch name for the pull request.'
       },
       title: {
         type: 'string',
-        description: 'Title of the created pull request.'
+        description: 'Pull request title.'
       },
       body: {
         type: 'string',
-        description: 'Body for the created pull request [string].'
+        description: 'Pull request description.'
       },
       message: {
         type: 'string',
-        description:
-          'The commit message for the new commit used to open the pull request'
+        description: 'Commit message'
       },
       remote: {
         type: 'string',

--- a/bin/cml/pr.js
+++ b/bin/cml/pr.js
@@ -49,13 +49,7 @@ exports.builder = (yargs) =>
       },
       body: {
         type: 'string',
-        conflicts: ['bodyFile'],
         description: 'Body for the created pull request [string].'
-      },
-      bodyFile: {
-        type: 'string',
-        conflicts: ['body'],
-        description: 'Body for the created pull request [relative filename]'
       },
       message: {
         type: 'string',

--- a/bin/cml/pr.js
+++ b/bin/cml/pr.js
@@ -39,6 +39,10 @@ exports.builder = (yargs) =>
         conflicts: ['merge', 'rebase'],
         description: 'Try to squash-merge the pull request upon creation.'
       },
+      branch: {
+        type: 'string',
+        description: 'set Custom branch name for pull request'
+      },
       title: {
         type: 'string',
         description: 'Title of the created pull request'

--- a/bin/cml/pr.js
+++ b/bin/cml/pr.js
@@ -49,8 +49,13 @@ exports.builder = (yargs) =>
       },
       body: {
         type: 'string',
-        description:
-          'Body for the created pull request [string or filename].'
+        conflicts: ['bodyFile'],
+        description: 'Body for the created pull request [string].'
+      },
+      bodyFile: {
+        type: 'string',
+        conflicts: ['body'],
+        description: 'Body for the created pull request [relative filename]'
       },
       message: {
         type: 'string',

--- a/bin/cml/pr.test.js
+++ b/bin/cml/pr.test.js
@@ -23,8 +23,8 @@ describe('CML e2e', () => {
                                                                              [boolean]
         --branch               Set a custom branch name for pull request.     [string]
         --title                Title of the created pull request.             [string]
-        --body                 Description/body of created pull request [string or
-                               file]. Ex \\"My cml pr\\", \\"reports/experiment-results.md\\"
+        --body                 Body for the created pull request [string].    [string]
+        --body-file            Body for the created pull request [relative filename]
                                                                               [string]
         --message              The commit message for the new commit used to open the
                                pull request                                   [string]

--- a/bin/cml/pr.test.js
+++ b/bin/cml/pr.test.js
@@ -24,7 +24,7 @@ describe('CML e2e', () => {
         --branch               Branch name for the pull request.              [string]
         --title                Pull request title.                            [string]
         --body                 Pull request description.                      [string]
-        --message              Commit message                                 [string]
+        --message              Commit message.                                [string]
         --remote               Sets git remote.           [string] [default: \\"origin\\"]
         --user-email           Sets git user email.
                                              [string] [default: \\"olivaw@iterative.ai\\"]

--- a/bin/cml/pr.test.js
+++ b/bin/cml/pr.test.js
@@ -24,8 +24,6 @@ describe('CML e2e', () => {
         --branch               Set a custom branch name for pull request.     [string]
         --title                Title of the created pull request.             [string]
         --body                 Body for the created pull request [string].    [string]
-        --body-file            Body for the created pull request [relative filename]
-                                                                              [string]
         --message              The commit message for the new commit used to open the
                                pull request                                   [string]
         --remote               Sets git remote.           [string] [default: \\"origin\\"]

--- a/bin/cml/pr.test.js
+++ b/bin/cml/pr.test.js
@@ -21,11 +21,10 @@ describe('CML e2e', () => {
                                                                              [boolean]
         --squash               Try to squash-merge the pull request upon creation.
                                                                              [boolean]
-        --branch               Set a custom branch name for pull request.     [string]
-        --title                Title of the created pull request.             [string]
-        --body                 Body for the created pull request [string].    [string]
-        --message              The commit message for the new commit used to open the
-                               pull request                                   [string]
+        --branch               Branch name for the pull request.              [string]
+        --title                Pull request title.                            [string]
+        --body                 Pull request description.                      [string]
+        --message              Commit message                                 [string]
         --remote               Sets git remote.           [string] [default: \\"origin\\"]
         --user-email           Sets git user email.
                                              [string] [default: \\"olivaw@iterative.ai\\"]

--- a/bin/cml/pr.test.js
+++ b/bin/cml/pr.test.js
@@ -21,6 +21,13 @@ describe('CML e2e', () => {
                                                                              [boolean]
         --squash               Try to squash-merge the pull request upon creation.
                                                                              [boolean]
+        --branch               Set a custom branch name for pull request.     [string]
+        --title                Title of the created pull request.             [string]
+        --body                 Description/body of created pull request [string or
+                               file]. Ex \\"My cml pr\\", \\"reports/experiment-results.md\\"
+                                                                              [string]
+        --message              The commit message for the new commit used to open the
+                               pull request                                   [string]
         --remote               Sets git remote.           [string] [default: \\"origin\\"]
         --user-email           Sets git user email.
                                              [string] [default: \\"olivaw@iterative.ai\\"]

--- a/src/cml.js
+++ b/src/cml.js
@@ -480,17 +480,16 @@ class CML {
       await exec(`git commit -m "${commitMessage}"`);
       await exec(`git push --set-upstream ${remote} ${source}`);
     }
-    const description =
-      body ||
-      `
-Automated commits for ${this.repo}/commit/${sha} created by CML.
-    `;
 
     const url = await driver.prCreate({
       source,
       target,
       title: title || `CML PR for ${target} ${shaShort}`,
-      description,
+      description:
+        body ||
+        `
+Automated commits for ${this.repo}/commit/${sha} created by CML.
+      `,
       autoMerge: merge
         ? 'merge'
         : rebase

--- a/src/cml.js
+++ b/src/cml.js
@@ -1,5 +1,4 @@
 const { execSync, spawnSync } = require('child_process');
-const fs = require('fs');
 const gitUrlParse = require('git-url-parse');
 const stripAuth = require('strip-url-auth');
 const globby = require('globby');
@@ -415,7 +414,6 @@ class CML {
       message,
       title,
       body,
-      bodyFile,
       merge,
       rebase,
       squash
@@ -482,19 +480,11 @@ class CML {
       await exec(`git commit -m "${commitMessage}"`);
       await exec(`git push --set-upstream ${remote} ${source}`);
     }
-    let description =
+    const description =
       body ||
       `
 Automated commits for ${this.repo}/commit/${sha} created by CML.
     `;
-    if (bodyFile) {
-      try {
-        description = (await fs.promises.readFile(bodyFile)).toString('utf8');
-      } catch (err) {
-        winston.error(`"${bodyFile}" is not a readable file.`);
-        throw err;
-      }
-    }
 
     const url = await driver.prCreate({
       source,

--- a/src/cml.js
+++ b/src/cml.js
@@ -484,8 +484,7 @@ class CML {
     let description;
     if (body) {
       try {
-        const buf = await fs.promises.readFile(body);
-        description = buf.toString('utf8');
+        description = (await fs.promises.readFile(body)).toString('utf8');
       } catch (err) {
         winston.debug(`"${body}" is not a readable file, passing it through`);
         description = body;

--- a/src/cml.js
+++ b/src/cml.js
@@ -482,11 +482,18 @@ class CML {
       await exec(`git commit -m "${commitMessage}"`);
       await exec(`git push --set-upstream ${remote} ${source}`);
     }
-    let description = body;
+    let description;
     if (body) {
-      const canRead = await fs.promises.access(body, fs.constants.R_OK);
-      if (canRead) {
-        description = (await fs.promises.readFile(body)).toString('utf8');
+      try {
+        const buf = await fs.promises.readFile(body);
+        console.log(buf);
+        console.log(buf.toString('utf8'));
+        description = buf.toString('uft8');
+        winston.info('desc: ' + description);
+      } catch (err) {
+        console.log(err);
+        winston.debug(`"${body}" is not a readable file, passing it through`);
+        description = body;
       }
     }
 

--- a/src/cml.js
+++ b/src/cml.js
@@ -414,7 +414,7 @@ class CML {
       branch,
       message,
       title,
-      body: description,
+      body,
       merge,
       rebase,
       squash

--- a/src/cml.js
+++ b/src/cml.js
@@ -485,7 +485,7 @@ class CML {
         commitMessage = `CML PR for ${shaShort}`;
       }
       winston.info('skipci, ' + skipCi);
-      if (skipCi || !message || !(merge || rebase || squash)) {
+      if (skipCi || (!message && !(merge || rebase || squash))) {
         commitMessage += ' [skip ci]';
       }
       await exec(`git commit -m "${commitMessage}"`);

--- a/src/cml.js
+++ b/src/cml.js
@@ -464,16 +464,11 @@ class CML {
 
       if (url) return renderPr(url);
     } else {
-      let commitMessage;
+      let commitMessage = message || `CML PR for ${shaShort}`;
       await exec(`git fetch ${remote} ${sha}`);
       await exec(`git checkout -B ${target} ${sha}`);
       await exec(`git checkout -b ${source}`);
       await exec(`git add ${paths.join(' ')}`);
-      if (message) {
-        commitMessage = message;
-      } else {
-        commitMessage = `CML PR for ${shaShort}`;
-      }
       if (skipCi || (!message && !(merge || rebase || squash))) {
         commitMessage += ' [skip ci]';
       }

--- a/src/cml.js
+++ b/src/cml.js
@@ -409,10 +409,21 @@ class CML {
       remote = GIT_REMOTE,
       globs = ['dvc.lock', '.gitignore'],
       md,
+<<<<<<< HEAD
       skipCi,
+||||||| parent of b64ef3b (This is a combination of 18 commits.)
+=======
+      branch,
+>>>>>>> b64ef3b (This is a combination of 18 commits.)
       message,
       title,
       body: description,
+<<<<<<< HEAD
+||||||| parent of b64ef3b (This is a combination of 18 commits.)
+      skipCI,
+=======
+      skipCi,
+>>>>>>> b64ef3b (This is a combination of 18 commits.)
       merge,
       rebase,
       squash
@@ -446,7 +457,7 @@ class CML {
     const shaShort = sha.substr(0, 8);
 
     const target = await this.branch();
-    const source = `${target}-cml-pr-${shaShort}`;
+    const source = branch || `${target}-cml-pr-${shaShort}`;
 
     const branchExists = (
       await exec(
@@ -473,7 +484,8 @@ class CML {
       } else {
         commitMessage = `CML PR for ${shaShort}`;
       }
-      if (skipCi || !(merge || rebase || squash)) {
+      winston.info('skipci, ' + skipCi);
+      if (skipCi || !message || !(merge || rebase || squash)) {
         commitMessage += ' [skip ci]';
       }
       await exec(`git commit -m "${commitMessage}"`);

--- a/src/cml.js
+++ b/src/cml.js
@@ -464,11 +464,11 @@ class CML {
 
       if (url) return renderPr(url);
     } else {
-      let commitMessage = message || `CML PR for ${shaShort}`;
       await exec(`git fetch ${remote} ${sha}`);
       await exec(`git checkout -B ${target} ${sha}`);
       await exec(`git checkout -b ${source}`);
       await exec(`git add ${paths.join(' ')}`);
+      let commitMessage = message || `CML PR for ${shaShort}`;
       if (skipCi || (!message && !(merge || rebase || squash))) {
         commitMessage += ' [skip ci]';
       }

--- a/src/cml.js
+++ b/src/cml.js
@@ -475,7 +475,6 @@ class CML {
       } else {
         commitMessage = `CML PR for ${shaShort}`;
       }
-      winston.info('skipci, ' + skipCi);
       if (skipCi || (!message && !(merge || rebase || squash))) {
         commitMessage += ' [skip ci]';
       }
@@ -486,12 +485,8 @@ class CML {
     if (body) {
       try {
         const buf = await fs.promises.readFile(body);
-        console.log(buf);
-        console.log(buf.toString('utf8'));
         description = buf.toString('utf8');
-        winston.info('desc: ' + description);
       } catch (err) {
-        console.log(err);
         winston.debug(`"${body}" is not a readable file, passing it through`);
         description = body;
       }

--- a/src/cml.js
+++ b/src/cml.js
@@ -1,4 +1,5 @@
 const { execSync, spawnSync } = require('child_process');
+const fs = require('fs');
 const gitUrlParse = require('git-url-parse');
 const stripAuth = require('strip-url-auth');
 const globby = require('globby');
@@ -409,21 +410,11 @@ class CML {
       remote = GIT_REMOTE,
       globs = ['dvc.lock', '.gitignore'],
       md,
-<<<<<<< HEAD
       skipCi,
-||||||| parent of b64ef3b (This is a combination of 18 commits.)
-=======
       branch,
->>>>>>> b64ef3b (This is a combination of 18 commits.)
       message,
       title,
       body: description,
-<<<<<<< HEAD
-||||||| parent of b64ef3b (This is a combination of 18 commits.)
-      skipCI,
-=======
-      skipCi,
->>>>>>> b64ef3b (This is a combination of 18 commits.)
       merge,
       rebase,
       squash
@@ -490,6 +481,13 @@ class CML {
       }
       await exec(`git commit -m "${commitMessage}"`);
       await exec(`git push --set-upstream ${remote} ${source}`);
+    }
+    let description = body;
+    if (body) {
+      const canRead = await fs.promises.access(body, fs.constants.R_OK);
+      if (canRead) {
+        description = (await fs.promises.readFile(body)).toString('utf8');
+      }
     }
 
     const url = await driver.prCreate({

--- a/src/cml.js
+++ b/src/cml.js
@@ -488,7 +488,7 @@ class CML {
         const buf = await fs.promises.readFile(body);
         console.log(buf);
         console.log(buf.toString('utf8'));
-        description = buf.toString('uft8');
+        description = buf.toString('utf8');
         winston.info('desc: ' + description);
       } catch (err) {
         console.log(err);


### PR DESCRIPTION
Closes: https://github.com/iterative/cml/issues/1017
Adds:
- `--branch` allow a use to set a custom branch name like `exp-12345` or `exp=${{  matrix.exp_id }}`
- `--title` PR title
- `--body` (maybe `--description` is better ?) body contents
- `--message` custom commit message

some examples:
`cml pr --title test --body="test pr body" --message="my commit message" .`
`cml pr --skip-ci --branch exp-1234 --message="my commit message" .`
~~`cml pr --title="Fancy PR Body" --body report.md  .`~~

if `--message` is provided the ` [skip ci]` notation is only added if `--skip-ci` is included. For example, `cml pr --squash .` would make a commit with `[skip ci]` present but `cml pr --messsage="my yolo pr" --squash`  would not, including `--skip-ci` explicitly adds ` [skip ci]` to the end of the provided message for this example resulting in a commit message of `my yolo pr [skip ci]`
