### PR TITLE
fix: Increase GHA workflow timeout to 35 days from 72h

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ environment variables for passing your cloud service credentials to the
 workflow.
 
 Note that `cml runner` will also automatically restart your jobs (whether from a
-[GitHub Actions 72-hour timeout](https://docs.github.com/en/actions/reference/usage-limits-billing-and-administration#usage-limits)
+[GitHub Actions 35 day workflow timeout](https://docs.github.com/en/actions/reference/usage-limits-billing-and-administration#usage-limits)
 or a
 [AWS EC2 spot instance interruption](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-interruptions.html)).
 
@@ -438,7 +438,7 @@ jobs:
   train-model:
     needs: deploy-runner
     runs-on: [self-hosted, cml-gpu]
-    timeout-minutes: 4320 # 72h
+    timeout-minutes: 4320 # 72h - up to 50400 (35d) supported
     container:
       image: docker://iterativeai/cml:0-dvc2-base1-gpu
       options: --gpus all

--- a/bin/cml/runner.js
+++ b/bin/cml/runner.js
@@ -15,7 +15,7 @@ let RUNNER_ID;
 let RUNNER_JOBS_RUNNING = [];
 let RUNNER_SHUTTING_DOWN = false;
 let RUNNER_TIMER = 0;
-const GH_5_MIN_TIMEOUT = (72 * 60 - 5) * 60 * 1000;
+const GHA_WORKFLOW_TIMEOUT = (35 * 24 * 60 - 5) * 60 * 1000;
 
 const shutdown = async (opts) => {
   if (RUNNER_SHUTTING_DOWN) return;
@@ -321,9 +321,9 @@ const runLocal = async (opts) => {
         RUNNER_JOBS_RUNNING.forEach((job) => {
           if (
             new Date().getTime() - new Date(job.date).getTime() >
-            GH_5_MIN_TIMEOUT
+            GHA_WORKFLOW_TIMEOUT
           ) {
-            shutdown({ ...opts, reason: 'timeout:72h' });
+            shutdown({ ...opts, reason: 'timeout:35d' });
             clearInterval(watcherSeventyTwo);
           }
         });


### PR DESCRIPTION
Noticed that there aren't really any tests for this in the runner - can potentially write one, or run cml-runner off this branch if you're happy for the PR to be open 35 days. 😂 