### PR TITLE
Fix telemetry unsupported async

### DIFF
--- a/bin/cml.js
+++ b/bin/cml.js
@@ -65,8 +65,9 @@ const setupTelemetry = async (opts) => {
 
 const runPlugin = async ({ $0: executable, command }) => {
   if (command === undefined) throw new Error('no command');
+  const { argv } = process.argv;
   const path = which.sync(`${basename(executable)}-${command}`);
-  const parameters = process.argv.slice(process.argv.indexOf(command) + 1); // HACK
+  const parameters = argv.slice(argv.indexOf(command) + 1); // HACK
   await pseudoexec(path, parameters);
 };
 

--- a/bin/cml.js
+++ b/bin/cml.js
@@ -44,14 +44,14 @@ const setupLogger = (opts) => {
           winston.format.simple()
         )
       : winston.format.combine(
-          winston.format.errors({ stack: false }),
+          winston.format.errors({ stack: true }),
           winston.format.json()
         ),
     transports: [
       new winston.transports.Console({
         stderrLevels: Object.keys(winston.config.npm.levels),
-        handleExceptions: false,
-        handleRejections: false,
+        handleExceptions: true,
+        handleRejections: true,
         level
       })
     ]

--- a/bin/cml.js
+++ b/bin/cml.js
@@ -8,8 +8,7 @@ const winston = require('winston');
 const yargs = require('yargs');
 
 const CML = require('../src/cml').default;
-const { jitsuEventPayload } = require('../src/analytics');
-let OPTS;
+const { jitsuEventPayload, send } = require('../src/analytics');
 
 const setupOpts = (opts) => {
   const legacyEnvironmentVariables = {
@@ -33,8 +32,6 @@ const setupOpts = (opts) => {
   opts.markdownFile = markdownfile;
   opts.cmlCommand = opts._[0];
   opts.cml = new CML(opts);
-
-  OPTS = opts;
 };
 
 const setupLogger = (opts) => {
@@ -47,14 +44,14 @@ const setupLogger = (opts) => {
           winston.format.simple()
         )
       : winston.format.combine(
-          winston.format.errors({ stack: true }),
+          winston.format.errors({ stack: false }),
           winston.format.json()
         ),
     transports: [
       new winston.transports.Console({
         stderrLevels: Object.keys(winston.config.npm.levels),
-        handleExceptions: true,
-        handleRejections: true,
+        handleExceptions: false,
+        handleRejections: false,
         level
       })
     ]
@@ -73,43 +70,49 @@ const runPlugin = async ({ $0: executable, command }) => {
   await pseudoexec(path, parameters);
 };
 
-const handleError = async (message, error, yargs) => {
-  if (error) {
-    const { telemetryEvent, cml } = OPTS;
-    const event = { ...telemetryEvent, error: error.message };
-    await cml.telemetrySend({ event });
-    return;
+const handleError = (message, error) => {
+  if (!error) {
+    yargs.showHelp();
+    console.error('\n' + message);
+    process.exit(1);
   }
-
-  yargs.showHelp();
-  console.error('\n' + message);
 };
 
-process.on('uncaughtException', async (err) => {
-  await handleError('', err, yargs);
-});
+(async () => {
+  try {
+    await yargs
+      .env('CML')
+      .options({
+        log: {
+          type: 'string',
+          description: 'Maximum log level',
+          choices: ['error', 'warn', 'info', 'debug'],
+          default: 'info'
+        }
+      })
+      .fail(handleError)
+      .middleware(setupOpts)
+      .middleware(setupLogger)
+      .middleware(setupTelemetry)
+      .commandDir('./cml', { exclude: /\.test\.js$/ })
+      .command(
+        '$0 <command>',
+        false,
+        (builder) => builder.strict(false),
+        runPlugin
+      )
+      .recommendCommands()
+      .demandCommand()
+      .strict()
+      .parse();
 
-process.on('unhandledRejection', async (reason) => {
-  await handleError('', new Error(reason), yargs);
-});
-
-yargs
-  .env('CML')
-  .options({
-    log: {
-      type: 'string',
-      description: 'Maximum log level',
-      choices: ['error', 'warn', 'info', 'debug'],
-      default: 'info'
-    }
-  })
-  .fail(handleError)
-  .middleware(setupOpts)
-  .middleware(setupLogger)
-  .middleware(setupTelemetry)
-  .commandDir('./cml', { exclude: /\.test\.js$/ })
-  .command('$0 <command>', false, (builder) => builder.strict(false), runPlugin)
-  .recommendCommands()
-  .demandCommand()
-  .strict()
-  .parse();
+    const { telemetryEvent } = yargs.parsed.argv;
+    await send({ event: telemetryEvent });
+  } catch (err) {
+    const { telemetryEvent } = yargs.parsed.argv;
+    const event = { ...telemetryEvent, error: err.message };
+    await send({ event });
+    winston.error({ err });
+    process.exit(1);
+  }
+})();

--- a/bin/cml/pr.js
+++ b/bin/cml/pr.js
@@ -11,10 +11,9 @@ exports.command = 'pr <glob path...>';
 exports.description = 'Create a pull request with the specified files';
 
 exports.handler = async (opts) => {
-  const { cml, telemetryEvent: event, globpath: globs } = opts;
+  const { cml, globpath: globs } = opts;
   const link = await cml.prCreate({ ...opts, globs });
   console.log(link);
-  await cml.telemetrySend({ event });
 };
 
 exports.builder = (yargs) =>

--- a/bin/cml/publish.js
+++ b/bin/cml/publish.js
@@ -15,14 +15,12 @@ exports.handler = async (opts) => {
     opts.native = true;
   }
 
-  const { file, repo, native, asset: path, telemetryEvent: event } = opts;
+  const { file, repo, native, asset: path } = opts;
   const cml = new CML({ ...opts, repo: native ? repo : 'cml' });
   const output = await cml.publish({ ...opts, path });
 
   if (!file) console.log(output);
   else await fs.writeFile(file, output);
-
-  await cml.telemetrySend({ event });
 };
 
 exports.builder = (yargs) =>

--- a/bin/cml/rerun-workflow.js
+++ b/bin/cml/rerun-workflow.js
@@ -6,9 +6,8 @@ exports.description = 'Reruns a workflow given the jobId or workflow Id';
 const { repoOptions } = require('../../src/cml');
 
 exports.handler = async (opts) => {
-  const { cml, telemetryEvent: event } = opts;
+  const { cml } = opts;
   await cml.pipelineRerun(opts);
-  await cml.telemetrySend({ event });
 };
 
 exports.builder = (yargs) =>

--- a/bin/cml/runner.js
+++ b/bin/cml/runner.js
@@ -420,10 +420,8 @@ exports.description = 'Launch and register a self-hosted runner';
 
 exports.handler = async (opts) => {
   ({ cml } = opts);
-  const { telemetryEvent: event } = opts;
   try {
     await run(opts);
-    await cml.telemetrySend({ event });
   } catch (error) {
     await shutdown({ ...opts, error });
   }

--- a/bin/cml/send-comment.js
+++ b/bin/cml/send-comment.js
@@ -6,9 +6,8 @@ exports.command = 'send-comment <markdown file>';
 exports.description = 'Comment on a commit';
 
 exports.handler = async (opts) => {
-  const { cml, telemetryEvent: event } = opts;
-  console.log(await opts.cml.commentCreate(opts));
-  await cml.telemetrySend({ event });
+  const { cml } = opts;
+  console.log(await cml.commentCreate(opts));
 };
 
 exports.builder = (yargs) =>

--- a/bin/cml/send-github-check.js
+++ b/bin/cml/send-github-check.js
@@ -7,10 +7,9 @@ exports.command = 'send-github-check <markdown file>';
 exports.description = 'Create a check report';
 
 exports.handler = async (opts) => {
-  const { cml, telemetryEvent: event, markdownfile } = opts;
+  const { cml, markdownfile } = opts;
   const report = await fs.readFile(markdownfile, 'utf-8');
-  await opts.cml.checkCreate({ ...opts, report });
-  await cml.telemetrySend({ event });
+  await cml.checkCreate({ ...opts, report });
 };
 
 exports.builder = (yargs) =>

--- a/bin/cml/tensorboard-dev.js
+++ b/bin/cml/tensorboard-dev.js
@@ -92,9 +92,6 @@ exports.handler = async (opts) => {
   const url = await launchAndWaitLink({ ...opts, extraParams });
   if (!file) console.log(url);
   else await fs.appendFile(file, url);
-
-  const { cml, telemetryEvent: event } = opts;
-  await cml.telemetrySend({ event });
 };
 
 exports.builder = (yargs) =>

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,6 @@
         "strip-url-auth": "^1.0.1",
         "tar": "^6.1.11",
         "tempy": "^0.6.0",
-        "timeout-signal": "^1.1.0",
         "timestring": "^6.0.0",
         "unist-util-visit": "^2.0.3",
         "uuid": "^8.3.2",
@@ -1400,17 +1399,6 @@
       "version": "2.0.6",
       "dev": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
     },
     "node_modules/acorn": {
       "version": "8.8.0",
@@ -3053,14 +3041,6 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/execa": {
@@ -5697,14 +5677,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/os.js": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/os.js/-/os.js-0.2.1.tgz",
-      "integrity": "sha512-PxCFo501IZfL8O8Bq3zLV+Q7ie82lI/budZBmTuVqyPgQC+auMNh0wcqFJsznZmi4JIKF3zSzJp4oqzfxx/4dA==",
-      "bin": {
-        "os.js": "bin/cli.js"
-      }
-    },
     "node_modules/p-limit": {
       "version": "1.3.0",
       "dev": true,
@@ -6904,17 +6876,6 @@
       "version": "2.3.8",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/timeout-signal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/timeout-signal/-/timeout-signal-1.1.0.tgz",
-      "integrity": "sha512-fuWY4tM1njcHCiOB7XkTmP0EOxzBkPbuQwPN+ZCzM6G0Tj4fMVgEffG/OPgiNUX48o+FhQEa2Oh4qjEDBCy5WQ==",
-      "dependencies": {
-        "abort-controller": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/timestring": {
       "version": "6.0.0",
@@ -8597,14 +8558,6 @@
       "version": "2.0.6",
       "dev": true
     },
-    "abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "requires": {
-        "event-target-shim": "^5.0.0"
-      }
-    },
     "acorn": {
       "version": "8.8.0"
     },
@@ -9622,11 +9575,6 @@
     },
     "esutils": {
       "version": "2.0.3"
-    },
-    "event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "execa": {
       "version": "5.1.1",
@@ -11301,10 +11249,6 @@
         "windows-release": "^5.0.1"
       }
     },
-    "os.js": {
-      "version": "https://registry.npmjs.org/os.js/-/os.js-0.2.1.tgz",
-      "integrity": "sha512-PxCFo501IZfL8O8Bq3zLV+Q7ie82lI/budZBmTuVqyPgQC+auMNh0wcqFJsznZmi4JIKF3zSzJp4oqzfxx/4dA=="
-    },
     "p-limit": {
       "version": "1.3.0",
       "dev": true,
@@ -12028,14 +11972,6 @@
     "through": {
       "version": "2.3.8",
       "dev": true
-    },
-    "timeout-signal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/timeout-signal/-/timeout-signal-1.1.0.tgz",
-      "integrity": "sha512-fuWY4tM1njcHCiOB7XkTmP0EOxzBkPbuQwPN+ZCzM6G0Tj4fMVgEffG/OPgiNUX48o+FhQEa2Oh4qjEDBCy5WQ==",
-      "requires": {
-        "abort-controller": "^3.0.0"
-      }
     },
     "timestring": {
       "version": "6.0.0"

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "strip-url-auth": "^1.0.1",
     "tar": "^6.1.11",
     "tempy": "^0.6.0",
-    "timeout-signal": "^1.1.0",
     "timestring": "^6.0.0",
     "unist-util-visit": "^2.0.3",
     "uuid": "^8.3.2",

--- a/src/cml.js
+++ b/src/cml.js
@@ -20,7 +20,6 @@ const {
   preventcacheUri,
   waitForever
 } = require('./utils');
-const analytics = require('../src/analytics');
 
 const { GITHUB_REPOSITORY, CI_PROJECT_URL, BITBUCKET_REPO_UUID } = process.env;
 
@@ -570,10 +569,6 @@ Automated commits for ${this.repo}/commit/${sha} created by CML.
 
   async pipelineJobs(opts) {
     return await this.getDriver().pipelineJobs(opts);
-  }
-
-  async telemetrySend({ event }) {
-    await analytics.send({ event });
   }
 
   logError(e) {


### PR DESCRIPTION
 yargs fail do not support `await` if used the app throws a strange uncontrolled ecmascript exception. Due to this `unhandledexception` and `unhandledrejection` events were triggered raising analytics three times that would not even execute doe the the ecmascript exception.

yargs seems also the throw the error after the fail function, something that it does not do it with the default handler.

This PR follow the amazing work that @0x2b3bfa0 did at #1124 to simplify the telemetry however the approach due to the mentioned error is a bit different

 - closes #1128 
 - closes #1127 
 - closes #1124 