### PR TITLE
Add support for `cml comment <verb> --publish-url`

### DIFF
--- a/bin/cml/comment/create.js
+++ b/bin/cml/comment/create.js
@@ -26,6 +26,10 @@ exports.options = kebabcaseKeys({
     type: 'boolean',
     description: 'Upload any local images found in the Markdown report'
   },
+  publishUrl: {
+    type: 'string',
+    description: 'Self-hosted image server URL'
+  },
   watch: {
     type: 'boolean',
     description: 'Watch for changes and automatically update the comment'

--- a/bin/cml/comment/create.js
+++ b/bin/cml/comment/create.js
@@ -28,6 +28,7 @@ exports.options = kebabcaseKeys({
   },
   publishUrl: {
     type: 'string',
+    default: 'https://asset.cml.dev',
     description: 'Self-hosted image server URL'
   },
   watch: {

--- a/bin/cml/comment/create.test.js
+++ b/bin/cml/comment/create.test.js
@@ -33,7 +33,8 @@ describe('Comment integration tests', () => {
                                                             [string] [default: \\"HEAD\\"]
         --publish                 Upload any local images found in the Markdown report
                                                                              [boolean]
-        --publish-url             Self-hosted image server URL                [string]
+        --publish-url             Self-hosted image server URL
+                                           [string] [default: \\"https://asset.cml.dev\\"]
         --watch                   Watch for changes and automatically update the
                                   comment                                    [boolean]
         --native                  Uses driver's native capabilities to upload assets
@@ -64,5 +65,12 @@ describe('Comment integration tests', () => {
 
     await fs.writeFile(path, report);
     await exec(`node ./bin/cml.js send-comment ${path}`);
+  });
+
+  test('cml send-comment --publish to current repo', async () => {
+    const report = `## Test Comment\n![](assets/logo.png)`;
+
+    await fs.writeFile(path, report);
+    await exec(`node ./bin/cml.js send-comment --publish ${path}`);
   });
 });

--- a/bin/cml/comment/create.test.js
+++ b/bin/cml/comment/create.test.js
@@ -33,6 +33,7 @@ describe('Comment integration tests', () => {
                                                             [string] [default: \\"HEAD\\"]
         --publish                 Upload any local images found in the Markdown report
                                                                              [boolean]
+        --publish-url             Self-hosted image server URL                [string]
         --watch                   Watch for changes and automatically update the
                                   comment                                    [boolean]
         --native                  Uses driver's native capabilities to upload assets

--- a/src/cml.js
+++ b/src/cml.js
@@ -167,6 +167,7 @@ class CML {
       update,
       pr,
       publish,
+      publishUrl,
       markdownFile,
       report: testReport,
       watch,
@@ -208,7 +209,11 @@ class CML {
           );
           if (!triggerFile && watch) watcher.add(absolutePath);
           try {
-            node.url = await this.publish({ ...opts, path: absolutePath });
+            node.url = await this.publish({
+              ...opts,
+              path: absolutePath,
+              url: publishUrl
+            });
           } catch (err) {
             if (err.code !== 'ENOENT') throw err;
           }


### PR DESCRIPTION
Required for https://github.com/iterative/cml.dev/issues/316
```
cml comment <create|update> --publish --publish-url=https://{identifier}.lambda-url.{region}.on.aws
```