### PR TITLE
Fix opaque error messages when not `isatty`

### DIFF
--- a/bin/cml.js
+++ b/bin/cml.js
@@ -157,7 +157,7 @@ const handleError = (message, error) => {
       const event = { ...telemetryEvent, error: err.message };
       await send({ event });
     }
-    winston.error({ err });
+    winston.error(err);
     process.exit(1);
   }
 })();


### PR DESCRIPTION
Otherwise, error messages will be invariably replaced with the string `{"level":"error","message":{"err":{}}}`