### PR TITLE
Exclude internal projects & tests from analytics

### DIFF
--- a/src/analytics.js
+++ b/src/analytics.js
@@ -185,7 +185,15 @@ const send = async ({
   try {
     if (ITERATIVE_DO_NOT_TRACK) return;
     if (!event.user_id || event.user_id === ID_DO_NOT_TRACK) return;
-
+    
+    // Exclude continuous integration tests and internal projects from analytics
+    if (
+      ['iterative', 'iterative-test'].includes(GITHUB_REPOSITORY_OWNER) ||
+      ['iterative.ai', 'iterative-test'].includes(CI_PROJECT_ROOT_NAMESPACE) ||
+      ['iterative-ai', 'iterative-test'].includes(BITBUCKET_WORKSPACE)
+    )
+      return;
+    
     const controller = new AbortController();
     const id = setTimeout(() => controller.abort(), 5 * 1000);
     await fetch(endpoint, {

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -21,6 +21,7 @@ const {
   GITHUB_SERVER_URL,
   GITHUB_REPOSITORY_OWNER,
   GITHUB_ACTOR,
+  GITHUB_REPOSITORY,
   CI_SERVER_URL,
   CI_PROJECT_ROOT_NAMESPACE,
   GITLAB_USER_NAME,
@@ -188,9 +189,10 @@ const send = async ({
     
     // Exclude continuous integration tests and internal projects from analytics
     if (
+      GITHUB_REPOSITORY.startsWith('iterative/') ||
       ['iterative', 'iterative-test'].includes(GITHUB_REPOSITORY_OWNER) ||
       ['iterative.ai', 'iterative-test'].includes(CI_PROJECT_ROOT_NAMESPACE) ||
-      ['iterative-ai', 'iterative-test'].includes(BITBUCKET_WORKSPACE)
+      ['iterative-ai', 'iterative-test'].includes(BITBUCKET_WORKSPACE) ||
     )
       return;
     

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -73,7 +73,7 @@ const groupId = async () => {
   } else if (ci === 'gitlab') {
     rawId = `${CI_SERVER_URL}/${CI_PROJECT_ROOT_NAMESPACE}`;
   } else if (ci === 'bitbucket') {
-    rawId = BITBUCKET_WORKSPACE;
+    rawId = `https://bitbucket.com/${BITBUCKET_WORKSPACE}`;
   }
 
   return await deterministic(rawId);
@@ -187,12 +187,19 @@ const send = async ({
     if (ITERATIVE_DO_NOT_TRACK) return;
     if (!event.user_id || event.user_id === ID_DO_NOT_TRACK) return;
 
+    // Exclude runs from GitHub Codespaces at Iterative
+    if (GITHUB_REPOSITORY.startsWith('iterative/')) return;
+
     // Exclude continuous integration tests and internal projects from analytics
     if (
-      GITHUB_REPOSITORY.startsWith('iterative/') ||
-      ['iterative', 'iterative-test'].includes(GITHUB_REPOSITORY_OWNER) ||
-      ['iterative.ai', 'iterative-test'].includes(CI_PROJECT_ROOT_NAMESPACE) ||
-      ['iterative-ai', 'iterative-test'].includes(BITBUCKET_WORKSPACE)
+      [
+        'dc16cd76-71b7-5afa-bf11-e85e02ee1554', // deterministic("https://github.com/iterative")
+        'b0e229bf-2598-54b7-a3e0-81869cdad579', // deterministic("https://github.com/iterative-test")
+        'd5aaeca4-fe6a-5c72-8aa7-6dcd65974973', // deterministic("https://gitlab.com/iterative.ai")
+        'b6df227b-5b3d-5190-a8fa-d272b617ee6c', // deterministic("https://gitlab.com/iterative-test")
+        '2c6415f0-cb5a-5e52-8c81-c5af4f11715d', // deterministic("https://bitbucket.com/iterative-ai")
+        'c0b86b90-d63c-5fb0-b84d-718d8e15f8d6' // deterministic("https://bitbucket.com/iterative-test")
+      ].includes(event.group_id)
     )
       return;
 

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -186,7 +186,7 @@ const send = async ({
   try {
     if (ITERATIVE_DO_NOT_TRACK) return;
     if (!event.user_id || event.user_id === ID_DO_NOT_TRACK) return;
-    
+
     // Exclude continuous integration tests and internal projects from analytics
     if (
       GITHUB_REPOSITORY.startsWith('iterative/') ||
@@ -195,7 +195,7 @@ const send = async ({
       ['iterative-ai', 'iterative-test'].includes(BITBUCKET_WORKSPACE)
     )
       return;
-    
+
     const controller = new AbortController();
     const id = setTimeout(() => controller.abort(), 5 * 1000);
     await fetch(endpoint, {

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -192,7 +192,7 @@ const send = async ({
       GITHUB_REPOSITORY.startsWith('iterative/') ||
       ['iterative', 'iterative-test'].includes(GITHUB_REPOSITORY_OWNER) ||
       ['iterative.ai', 'iterative-test'].includes(CI_PROJECT_ROOT_NAMESPACE) ||
-      ['iterative-ai', 'iterative-test'].includes(BITBUCKET_WORKSPACE) ||
+      ['iterative-ai', 'iterative-test'].includes(BITBUCKET_WORKSPACE)
     )
       return;
     


### PR DESCRIPTION
I chose this approach versus setting `ITERATIVE_DO_NOT_TRACK` on all the workflows because we have dozens of them split over a lot of repositories.

Local development may still require additional precautions like setting the `ITERATIVE_DO_NOT_TRACK` environment variable locally.

Thanks, @omesser for noticing! :pray: 