### PR TITLE
Enable `cml comment create --publish` by default

### DIFF
--- a/bin/cml/comment/create.js
+++ b/bin/cml/comment/create.js
@@ -24,6 +24,7 @@ exports.options = kebabcaseKeys({
   },
   publish: {
     type: 'boolean',
+    default: true,
     description: 'Upload any local images found in the Markdown report'
   },
   publishUrl: {

--- a/bin/cml/comment/create.test.js
+++ b/bin/cml/comment/create.test.js
@@ -23,7 +23,7 @@ describe('Comment integration tests', () => {
         --commit-sha, --head-sha  Commit SHA linked to this comment
                                                             [string] [default: \\"HEAD\\"]
         --publish                 Upload any local images found in the Markdown report
-                                                                             [boolean]
+                                                             [boolean] [default: true]
         --publish-url             Self-hosted image server URL
                                            [string] [default: \\"https://asset.cml.dev\\"]
         --watch                   Watch for changes and automatically update the


### PR DESCRIPTION
Behavior only changes for local Markdown links