### PR TITLE
Configure winston logging when running terraform tests

### DIFF
--- a/src/terraform.test.js
+++ b/src/terraform.test.js
@@ -1,6 +1,18 @@
+const winston = require('winston');
 const { iterativeCmlRunnerTpl } = require('./terraform');
 
 describe('Terraform tests', () => {
+  beforeAll(() => {
+    winston.configure({
+      transports: [
+        new winston.transports.Console({
+          level: 'error',
+          handleExceptions: true
+        })
+      ]
+    });
+  });
+
   test('default options', async () => {
     const output = iterativeCmlRunnerTpl({});
     expect(JSON.stringify(output, null, 2)).toMatchInlineSnapshot(`


### PR DESCRIPTION
Otherwise warnings are printed about unconfigured transports.