### PR TITLE
Add comment target flag and parsing

### DIFF
--- a/bin/cml/comment/create.js
+++ b/bin/cml/comment/create.js
@@ -25,7 +25,6 @@ exports.options = kebabcaseKeys({
       "Specify 'issue#123' to create a comment on a specific issue. " +
       "The default 'auto' will create a PR comment if running in a forge PR-related action " +
       'or if HEAD is in a PR branch. Otherwise a commit comment will be created.',
-    conflicts: ['pr', 'issue', 'commitSha'],
     default: 'auto'
   },
   pr: {

--- a/bin/cml/comment/create.js
+++ b/bin/cml/comment/create.js
@@ -23,9 +23,8 @@ exports.options = kebabcaseKeys({
     description:
       'Forge object to create comment on, can be one of pr, commit or issue. ' +
       "Specify 'issue#123' to create a comment on a specific issue. " +
-      "The default 'auto' will create a PR comment if running in a forge PR-related action " +
-      'or if HEAD is in a PR branch. Otherwise a commit comment will be created.',
-    default: 'auto'
+      'By default cml will create a PR comment if running in a forge PR-related action ' +
+      'or if HEAD is in a PR branch. Otherwise a commit comment will be created.'
   },
   pr: {
     type: 'boolean',

--- a/bin/cml/comment/create.js
+++ b/bin/cml/comment/create.js
@@ -18,6 +18,13 @@ exports.builder = (yargs) =>
     .options(exports.options);
 
 exports.options = kebabcaseKeys({
+  target: {
+    type: 'string',
+    description:
+      'Forge object to create comment on, can be one of pr, commit or issue.' +
+      "Specify 'issue#123' to create a comment on a specific issue.",
+    conflicts: ['pr', 'issue', 'commitSha']
+  },
   pr: {
     type: 'boolean',
     description:

--- a/bin/cml/comment/create.js
+++ b/bin/cml/comment/create.js
@@ -31,11 +31,6 @@ exports.options = kebabcaseKeys({
       'Post to an existing PR/MR associated with the specified commit',
     conflicts: ['issue']
   },
-  issue: {
-    type: 'number',
-    description: 'Post to the given issue number',
-    conflicts: ['pr']
-  },
   commitSha: {
     type: 'string',
     alias: 'head-sha',

--- a/bin/cml/comment/create.js
+++ b/bin/cml/comment/create.js
@@ -30,12 +30,13 @@ exports.options = kebabcaseKeys({
     type: 'boolean',
     description:
       'Post to an existing PR/MR associated with the specified commit',
-    conflicts: ['issue']
+    conflicts: ['target', 'commitSha']
   },
   commitSha: {
     type: 'string',
     alias: 'head-sha',
-    description: 'Commit SHA linked to this comment'
+    description: 'Commit SHA linked to this comment',
+    conflicts: ['target', 'pr']
   },
   watch: {
     type: 'boolean',

--- a/bin/cml/comment/create.js
+++ b/bin/cml/comment/create.js
@@ -37,7 +37,6 @@ exports.options = kebabcaseKeys({
   commitSha: {
     type: 'string',
     alias: 'head-sha',
-    default: 'HEAD',
     description: 'Commit SHA linked to this comment'
   },
   watch: {

--- a/bin/cml/comment/create.js
+++ b/bin/cml/comment/create.js
@@ -21,9 +21,12 @@ exports.options = kebabcaseKeys({
   target: {
     type: 'string',
     description:
-      'Forge object to create comment on, can be one of pr, commit or issue.' +
-      "Specify 'issue#123' to create a comment on a specific issue.",
-    conflicts: ['pr', 'issue', 'commitSha']
+      'Forge object to create comment on, can be one of pr, commit or issue. ' +
+      "Specify 'issue#123' to create a comment on a specific issue. " +
+      "The default 'auto' will create a PR comment if running in a forge PR-related action " +
+      'or if HEAD is in a PR branch. Otherwise a commit comment will be created.',
+    conflicts: ['pr', 'issue', 'commitSha'],
+    default: 'auto'
   },
   pr: {
     type: 'boolean',

--- a/bin/cml/comment/create.test.js
+++ b/bin/cml/comment/create.test.js
@@ -19,8 +19,12 @@ describe('Comment integration tests', () => {
 
       Options:
         --target                    Forge object to create comment on, can be one of
-                                    pr, commit or issue.Specify 'issue#123' to create
-                                    a comment on a specific issue.            [string]
+                                    pr, commit or issue. Specify 'issue#123' to create
+                                    a comment on a specific issue. The default 'auto'
+                                    will create a PR comment if running in a forge
+                                    PR-related action or if HEAD is in a PR branch.
+                                    Otherwise a commit comment will be created.
+                                                            [string] [default: \\"auto\\"]
         --pr                        Post to an existing PR/MR associated with the
                                     specified commit                         [boolean]
         --commit-sha, --head-sha    Commit SHA linked to this comment

--- a/bin/cml/comment/create.test.js
+++ b/bin/cml/comment/create.test.js
@@ -19,11 +19,11 @@ describe('Comment integration tests', () => {
       Options:
         --target                    Forge object to create comment on, can be one of
                                     pr, commit or issue. Specify 'issue#123' to create
-                                    a comment on a specific issue. The default 'auto'
-                                    will create a PR comment if running in a forge
+                                    a comment on a specific issue. By default cml will
+                                    create a PR comment if running in a forge
                                     PR-related action or if HEAD is in a PR branch.
                                     Otherwise a commit comment will be created.
-                                                            [string] [default: \\"auto\\"]
+                                                                              [string]
         --pr                        Post to an existing PR/MR associated with the
                                     specified commit                         [boolean]
         --commit-sha, --head-sha    Commit SHA linked to this comment         [string]

--- a/bin/cml/comment/create.test.js
+++ b/bin/cml/comment/create.test.js
@@ -27,8 +27,7 @@ describe('Comment integration tests', () => {
                                                             [string] [default: \\"auto\\"]
         --pr                        Post to an existing PR/MR associated with the
                                     specified commit                         [boolean]
-        --commit-sha, --head-sha    Commit SHA linked to this comment
-                                                            [string] [default: \\"HEAD\\"]
+        --commit-sha, --head-sha    Commit SHA linked to this comment         [string]
         --watch                     Watch for changes and automatically update the
                                     comment                                  [boolean]
         --publish                   Upload any local images found in the Markdown

--- a/bin/cml/comment/create.test.js
+++ b/bin/cml/comment/create.test.js
@@ -23,7 +23,6 @@ describe('Comment integration tests', () => {
                                     a comment on a specific issue.            [string]
         --pr                        Post to an existing PR/MR associated with the
                                     specified commit                         [boolean]
-        --issue                     Post to the given issue number            [number]
         --commit-sha, --head-sha    Commit SHA linked to this comment
                                                             [string] [default: \\"HEAD\\"]
         --watch                     Watch for changes and automatically update the

--- a/bin/cml/comment/create.test.js
+++ b/bin/cml/comment/create.test.js
@@ -18,6 +18,9 @@ describe('Comment integration tests', () => {
         --help    Show help                                                  [boolean]
 
       Options:
+        --target                    Forge object to create comment on, can be one of
+                                    pr, commit or issue.Specify 'issue#123' to create
+                                    a comment on a specific issue.            [string]
         --pr                        Post to an existing PR/MR associated with the
                                     specified commit                         [boolean]
         --issue                     Post to the given issue number            [number]

--- a/src/cml.js
+++ b/src/cml.js
@@ -164,7 +164,6 @@ class CML {
   async commentCreate(opts = {}) {
     const {
       commitSha: inCommitSha,
-      issue: issueId,
       rmWatermark,
       update,
       pr,
@@ -272,16 +271,13 @@ class CML {
 
     const target = await parseCommentTarget({
       commitSha,
-      issue: issueId,
       pr,
       target: commentTarget,
       drv
     });
 
     if (update) {
-      comment = updatableComment(
-        await drv[target.target + 'Comments']({ issueId })
-      );
+      comment = updatableComment(await drv[target.target + 'Comments'](target));
 
       if (comment)
         return await drv[target.target + 'CommentUpdate']({

--- a/src/cml.js
+++ b/src/cml.js
@@ -299,7 +299,7 @@ class CML {
     };
 
     const target = await parseCommentTarget({
-      inCommitSha,
+      commitSha: inCommitSha,
       pr,
       target: commentTarget,
       drv

--- a/src/cml.js
+++ b/src/cml.js
@@ -176,9 +176,6 @@ class CML {
       triggerFile
     } = opts;
 
-    const commitSha =
-      (await this.revParse({ ref: inCommitSha })) || inCommitSha;
-
     if (rmWatermark && update)
       throw new Error('watermarks are mandatory for updateable comments');
 
@@ -270,7 +267,7 @@ class CML {
     };
 
     const target = await parseCommentTarget({
-      commitSha,
+      inCommitSha,
       pr,
       target: commentTarget,
       drv

--- a/src/cml.js
+++ b/src/cml.js
@@ -164,7 +164,7 @@ class CML {
 
   async commentCreate(opts = {}) {
     const {
-      commitSha: inCommitSha,
+      commitSha,
       markdownFile,
       pr,
       publish,
@@ -299,7 +299,7 @@ class CML {
     };
 
     const target = await parseCommentTarget({
-      commitSha: inCommitSha,
+      commitSha,
       pr,
       target: commentTarget,
       drv

--- a/src/cml.js
+++ b/src/cml.js
@@ -171,7 +171,7 @@ class CML {
       publishUrl,
       markdownFile,
       report: testReport,
-      target: commentTarget,
+      target: commentTarget = 'auto',
       watch,
       triggerFile
     } = opts;

--- a/src/commenttarget.js
+++ b/src/commenttarget.js
@@ -16,7 +16,7 @@ async function parseCommentTarget(opts = {}) {
     commentTarget = 'pr';
   }
   // Handle comment targets that are incomplete, e.g. 'pr' or 'commit'.
-  let prId;
+  let prNumber;
   let commitPr;
   switch (commentTarget) {
     case 'commit':
@@ -24,16 +24,16 @@ async function parseCommentTarget(opts = {}) {
     case 'pr':
     case 'auto':
       // Determine PR id from forge env vars (if we're in a PR context).
-      prId = drv.pr;
-      if (prId) {
-        return { target: 'pr', prNumber: prId };
+      prNumber = drv.pr;
+      if (prNumber) {
+        return { target: 'pr', prNumber: prNumber };
       }
       // Or fallback to determining PR by HEAD commit.
       // TODO: handle issue with PR HEAD commit not matching source branch in github.
       [commitPr = {}] = await drv.commitPrs({ commitSha: drv.sha });
       if (commitPr.url) {
-        [prId] = commitPr.url.split('/').slice(-1);
-        return { target: 'pr', prNumber: prId };
+        [prNumber] = commitPr.url.split('/').slice(-1);
+        return { target: 'pr', prNumber };
       }
       // If target is 'auto', fallback to issuing commit comments.
       if (commentTarget === 'auto') {

--- a/src/commenttarget.js
+++ b/src/commenttarget.js
@@ -1,16 +1,10 @@
 const SEPARATOR = '#';
 
 async function parseCommentTarget(opts = {}) {
-  const { commitSha: commit, issue, pr, target, drv } = opts;
+  const { commitSha: commit, pr, target, drv } = opts;
 
   let commentTarget = target;
   // Handle legacy comment target flags.
-  if (issue) {
-    drv.warn(
-      'cml: the --issue flag will be deprecated, please use --target="issue#123"'
-    );
-    commentTarget = `issue#${issue}`;
-  }
   if (commit) {
     drv.warn(
       'cml: the --commitSha flag will be deprecated, please use --target="commit#<sha>"'

--- a/src/commenttarget.js
+++ b/src/commenttarget.js
@@ -1,0 +1,64 @@
+const SEPARATOR = '#';
+
+async function parseCommentTarget(opts = {}) {
+  const { commitSha: commit, issue, pr, target, drv } = opts;
+
+  let commentTarget = target;
+  // Handle legacy comment target flags.
+  if (issue) {
+    drv.warn(
+      'cml: the --issue flag will be deprecated, please use --target="issue#123"'
+    );
+    commentTarget = `issue#${issue}`;
+  }
+  if (commit) {
+    drv.warn(
+      'cml: the --commitSha flag will be deprecated, please use --target="commit#<sha>"'
+    );
+    commentTarget = `commit#${commit}`;
+  }
+  if (pr) {
+    drv.warn('cml: the --pr flag will be deprecated, please use --target="pr"');
+    commentTarget = 'pr';
+  }
+  // Handle comment targets that are incomplete, e.g. 'pr' or 'commit'.
+  let prId;
+  let commitPr;
+  switch (commentTarget) {
+    case 'commit':
+      return { target: 'commit', commitSha: drv.sha };
+    case 'pr':
+      // Determine PR id from forge env vars (if we're in a PR context).
+      prId = drv.pr;
+      if (prId) {
+        return { target: 'pr', prNumber: prId };
+      }
+      // Or fallback to determining PR by HEAD commit.
+      // TODO: handle issue with PR HEAD commit not matching source branch in github.
+      [commitPr = {}] = await drv.commitPrs({ commitSha: drv.sha });
+      if (!commitPr.url) {
+        throw new Error(`PR for commit sha "${drv.sha}" not found`);
+      }
+      [prId] = commitPr.url.split('/').slice(-1);
+      return { target: 'pr', prNumber: prId };
+  }
+  // Handle qualified comment targets, e.g. 'issue#id'.
+  const separatorPos = commentTarget.indexOf(SEPARATOR);
+  if (separatorPos === -1) {
+    throw new Error(`comment target "${commentTarget}" could not be parsed`);
+  }
+  const targetType = commentTarget.slice(0, separatorPos);
+  const id = commentTarget.slice(separatorPos + 1);
+  switch (targetType) {
+    case 'commit':
+      return { target: targetType, commitSha: id };
+    case 'pr':
+      return { target: targetType, prNumber: id };
+    case 'issue':
+      return { target: targetType, issueId: id };
+    default:
+      throw new Error(`unsupported comment target "${commentTarget}"`);
+  }
+}
+
+module.exports = { parseCommentTarget };

--- a/src/commenttarget.test.js
+++ b/src/commenttarget.test.js
@@ -1,0 +1,130 @@
+const { parseCommentTarget } = require('../src/commenttarget');
+
+describe('comment target tests', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test('qualified comment target: pr', async () => {
+    const target = await parseCommentTarget({
+      target: 'pr#3'
+    });
+    expect(target).toEqual({ target: 'pr', prNumber: '3' });
+  });
+
+  test('qualified comment target: commit', async () => {
+    const target = await parseCommentTarget({
+      target: 'commit#abcdefg'
+    });
+    expect(target).toEqual({ target: 'commit', commitSha: 'abcdefg' });
+  });
+
+  test('qualified comment target: issue', async () => {
+    const target = await parseCommentTarget({
+      target: 'issue#3'
+    });
+    expect(target).toEqual({ target: 'issue', issueId: '3' });
+  });
+
+  test('qualified comment target: unsupported', async () => {
+    try {
+      await parseCommentTarget({
+        target: 'unsupported#3'
+      });
+    } catch (error) {
+      expect(error.message).toBe('unsupported comment target "unsupported#3"');
+    }
+  });
+
+  test('legacy flag: commitSha', async () => {
+    const drv = { warn: () => {} };
+    const target = await parseCommentTarget({
+      drv,
+      commitSha: 'abcdefg',
+      target: 'issue#3' // target will be replaced with commit
+    });
+    expect(target).toEqual({ target: 'commit', commitSha: 'abcdefg' });
+  });
+
+  // Test retrieving the PR id from the driver's context.
+  test('legacy flag: pr, context', async () => {
+    const drv = {
+      warn: () => {},
+      pr: '4' // driver returns the PR id from context
+    };
+    const target = await parseCommentTarget({
+      drv,
+      pr: true,
+      target: 'issue#3' // target will be replaced
+    });
+    expect(target).toEqual({ target: 'pr', prNumber: '4' });
+  });
+
+  // Test calculating the PR id based on the commit sha.
+  test('legacy flag: pr, commit sha', async () => {
+    const drv = {
+      warn: () => {},
+      pr: null, // not in PR context
+      commitPrs: () => [{ url: 'forge/pr/4' }],
+      sha: 'abcdefg'
+    };
+    const target = await parseCommentTarget({
+      drv,
+      pr: true,
+      target: 'issue#3' // target will be replaced
+    });
+    expect(target).toEqual({ target: 'pr', prNumber: '4' });
+  });
+
+  // Test using driver supplied commit sha.
+  test('unqualified flag: commit sha', async () => {
+    const drv = {
+      warn: () => {},
+      sha: 'abcdefg'
+    };
+    const target = await parseCommentTarget({
+      drv,
+      target: 'commit'
+    });
+    expect(target).toEqual({ target: 'commit', commitSha: 'abcdefg' });
+  });
+
+  // Test retrieving the PR id from the driver's context.
+  test('unqualified flag: pr, context', async () => {
+    const drv = {
+      warn: () => {},
+      pr: '4' // driver returns the PR id from context
+    };
+    const target = await parseCommentTarget({
+      drv,
+      target: 'pr' // target will be replaced
+    });
+    expect(target).toEqual({ target: 'pr', prNumber: '4' });
+  });
+
+  // Test calculating the PR id based on the commit sha.
+  test('unqualified flag: pr, commit sha', async () => {
+    const drv = {
+      warn: () => {},
+      pr: null, // not in PR context
+      commitPrs: () => [{ url: 'forge/pr/4' }],
+      sha: 'abcdefg'
+    };
+    const target = await parseCommentTarget({
+      drv,
+      pr: true,
+      target: 'pr' // target will be replaced
+    });
+    expect(target).toEqual({ target: 'pr', prNumber: '4' });
+  });
+
+  test('unqualified comment target: issue', async () => {
+    try {
+      await parseCommentTarget({
+        target: 'issue'
+      });
+    } catch (error) {
+      expect(error.message).toBe('comment target "issue" could not be parsed');
+    }
+  });
+});

--- a/src/commenttarget.test.js
+++ b/src/commenttarget.test.js
@@ -127,4 +127,47 @@ describe('comment target tests', () => {
       expect(error.message).toBe('comment target "issue" could not be parsed');
     }
   });
+
+  test('auto comment target: pr context', async () => {
+    const drv = {
+      warn: () => {},
+      pr: '4' // driver returns the PR id from context
+    };
+
+    const target = await parseCommentTarget({
+      drv,
+      target: 'auto'
+    });
+    expect(target).toEqual({ target: 'pr', prNumber: '4' });
+  });
+
+  test('auto comment target: pr, commit sha', async () => {
+    const drv = {
+      warn: () => {},
+      pr: null, // not in PR context
+      commitPrs: () => [{ url: 'forge/pr/5' }],
+      sha: 'abcdefg'
+    };
+
+    const target = await parseCommentTarget({
+      drv,
+      target: 'auto'
+    });
+    expect(target).toEqual({ target: 'pr', prNumber: '5' });
+  });
+
+  test('auto comment target: fallback commit sha', async () => {
+    const drv = {
+      warn: () => {},
+      pr: null, // not in PR context
+      commitPrs: () => [],
+      sha: 'abcdefg'
+    };
+
+    const target = await parseCommentTarget({
+      drv,
+      target: 'auto'
+    });
+    expect(target).toEqual({ target: 'commit', commitSha: 'abcdefg' });
+  });
 });

--- a/src/drivers/bitbucket_cloud.e2e.test.js
+++ b/src/drivers/bitbucket_cloud.e2e.test.js
@@ -25,7 +25,7 @@ describe('Non Enviromental tests', () => {
   test('Comment', async () => {
     const report = '## Test comment';
     const commitSha = SHA;
-    const url = await client.commentCreate({ report, commitSha });
+    const url = await client.commitCommentCreate({ report, commitSha });
 
     expect(url.startsWith(REPO)).toBe(true);
   });

--- a/src/drivers/bitbucket_cloud.js
+++ b/src/drivers/bitbucket_cloud.js
@@ -67,7 +67,7 @@ class BitbucketCloud {
     );
   }
 
-  async commentCreate(opts = {}) {
+  async commitCommentCreate(opts = {}) {
     const { projectPath } = this;
     const { commitSha, report } = opts;
 
@@ -81,7 +81,7 @@ class BitbucketCloud {
     ).links.html.href;
   }
 
-  async commentUpdate(opts = {}) {
+  async commitCommentUpdate(opts = {}) {
     const { projectPath } = this;
     const { commitSha, report, id } = opts;
 
@@ -463,6 +463,16 @@ class BitbucketCloud {
     return BITBUCKET_COMMIT;
   }
 
+  /**
+   * Returns the PR number if we're in a PR-related action event.
+   */
+  get pr() {
+    if ('BITBUCKET_PR_ID' in process.env) {
+      return process.env.BITBUCKET_PR_ID;
+    }
+    return null;
+  }
+
   get branch() {
     return BITBUCKET_BRANCH;
   }
@@ -523,6 +533,10 @@ class BitbucketCloud {
     }
 
     return responseBody;
+  }
+
+  warn(message) {
+    console.error(message);
   }
 }
 

--- a/src/drivers/bitbucket_cloud.js
+++ b/src/drivers/bitbucket_cloud.js
@@ -548,7 +548,7 @@ class BitbucketCloud {
   }
 
   warn(message) {
-    console.error(message);
+    winston.warn(message);
   }
 }
 

--- a/src/drivers/github.e2e.test.js
+++ b/src/drivers/github.e2e.test.js
@@ -31,7 +31,7 @@ describe('Non Enviromental tests', () => {
   test('Comment', async () => {
     const report = '## Test comment';
     const commitSha = SHA;
-    const url = await client.commentCreate({ report, commitSha });
+    const url = await client.commitCommentCreate({ report, commitSha });
 
     expect(url.startsWith(REPO)).toBe(true);
   });

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -100,7 +100,7 @@ class Github {
     return user;
   }
 
-  async commentCreate(opts = {}) {
+  async commitCommentCreate(opts = {}) {
     const { report: body, commitSha } = opts;
     const { repos } = octokit(this.token, this.repo);
 
@@ -113,7 +113,7 @@ class Github {
     ).data.html_url;
   }
 
-  async commentUpdate(opts = {}) {
+  async commitCommentUpdate(opts = {}) {
     const { report: body, id } = opts;
     const { repos } = octokit(this.token, this.repo);
 
@@ -765,6 +765,16 @@ class Github {
       return github.context.payload.pull_request.head.sha;
 
     return GITHUB_SHA;
+  }
+
+  /**
+   * Returns the PR number if we're in a PR-related action event.
+   */
+  get pr() {
+    if (['pull_request', 'pull_request_target'].includes(GITHUB_EVENT_NAME)) {
+      return github.context.payload.pull_request.number;
+    }
+    return null;
   }
 
   get branch() {

--- a/src/drivers/gitlab.e2e.test.js
+++ b/src/drivers/gitlab.e2e.test.js
@@ -26,7 +26,7 @@ describe('Non Enviromental tests', () => {
   test('Comment', async () => {
     const report = '## Test comment';
     const commitSha = SHA;
-    const url = await client.commentCreate({
+    const url = await client.commitCommentCreate({
       report,
       commitSha
     });

--- a/src/drivers/gitlab.js
+++ b/src/drivers/gitlab.js
@@ -548,7 +548,7 @@ class Gitlab {
   }
 
   warn(message) {
-    console.error(message);
+    winston.warn(message);
   }
 }
 

--- a/src/drivers/gitlab.js
+++ b/src/drivers/gitlab.js
@@ -65,7 +65,7 @@ class Gitlab {
     return this.detectedBase;
   }
 
-  async commentCreate(opts = {}) {
+  async commitCommentCreate(opts = {}) {
     const { commitSha, report } = opts;
 
     const projectPath = await this.projectPath();
@@ -78,7 +78,7 @@ class Gitlab {
     return `${this.repo}/-/commit/${commitSha}`;
   }
 
-  async commentUpdate(opts = {}) {
+  async commitCommentUpdate(opts = {}) {
     throw new Error('GitLab does not support comment updates!');
   }
 
@@ -493,6 +493,16 @@ class Gitlab {
     return process.env.CI_COMMIT_SHA;
   }
 
+  /**
+   * Returns the PR number if we're in a PR-related action event.
+   */
+  get pr() {
+    if ('CI_MERGE_REQUEST_IID' in process.env) {
+      return process.env.CI_MERGE_REQUEST_IID;
+    }
+    return null;
+  }
+
   get branch() {
     return process.env.CI_BUILD_REF_NAME;
   }
@@ -526,6 +536,10 @@ class Gitlab {
     if (raw) return response;
 
     return await response.json();
+  }
+
+  warn(message) {
+    console.error(message);
   }
 }
 


### PR DESCRIPTION
One significant change in this PR is that bitbucket commit comments will no longer be automatically posted at the PR level.

The `--target=auto` scenario is not yet being handled in this PR, this will be implemented in a follow-up.

The general idea is as follows:

- legacy comment target flags (`--pr`, `--commitSha`) take precendence.
- the `--issue` flag will be removed in a follow-up (replaced with `--target=issue#id`)
- the `--target` flag can take both qualified (`--target=pr#id` or `--target=commit#sha` or `--target=issue#id`) and unqualified values (`--target=pr` or `--target=commit`)
- when parsing an unqualified `pr` target, cml will first attempt to determine the PR number using the forge context (env vars for bitbucket and gitlab, `context.pull_request.number` for github) - if that fails, an attempt will be made to determine the pr number using the sha of the head commit
- when parsing an unqualified `commit` target, comments will be attached to the head commit