### PR TITLE
Warning on pre-existing branch in cml -pr

### DIFF
--- a/src/cml.js
+++ b/src/cml.js
@@ -569,6 +569,7 @@ class CML {
     ).includes(source);
 
     if (branchExists) {
+      driver.warn(`Branch ${source} already exists`);
       const prs = await driver.prs();
       const { url } =
         prs.find(

--- a/src/drivers/bitbucket_cloud.js
+++ b/src/drivers/bitbucket_cloud.js
@@ -425,6 +425,10 @@ class BitbucketCloud {
     return command;
   }
 
+  warn(message) {
+    winston.warn(message);
+  }
+
   get workflowId() {
     return BITBUCKET_PIPELINE_UUID;
   }

--- a/src/drivers/gitlab.js
+++ b/src/drivers/gitlab.js
@@ -445,6 +445,10 @@ class Gitlab {
     return command;
   }
 
+  warn(message) {
+    winston.warn(message);
+  }
+
   get workflowId() {
     return CI_PIPELINE_ID;
   }


### PR DESCRIPTION
Adds a warning if `cml -pr` fails to create pr due to conflicting branch.

By looking at the code, the behaviour seems to be that if a conflicting branch exists we look for a pr of that branch and show it if it exists OR create a pr for that branch and show that - does that make sense or should we not show anything if the branch cannot be created?

Fixes #758