### PR TITLE
replace set-output => GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -57,7 +57,7 @@ jobs:
           --header "PRIVATE-TOKEN: ${{ github.token }}" \
           --request GET \
           | jq -r .id \
-          | xargs -0 printf "::set-output name=hash::%s"
+          | xargs -0 printf "hash=%s" >> $GITHUB_OUTPUT
       - run: npm ci
       - name: Run cml-send-comment
         run: |

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -49,14 +49,14 @@ jobs:
                   key=Ver
               )
           )')
-          echo ::set-output name=cache_tag::${cml_version}-${dvc_version}-${{ matrix.base }}-${{ matrix.gpu }}
-          echo ::set-output name=cml_version::$cml_version
+          echo cache_tag=${cml_version}-${dvc_version}-${{ matrix.base }}-${{ matrix.gpu }} >> $GITHUB_OUTPUT
+          echo cml_version=$cml_version >> $GITHUB_OUTPUT
           tag=${cml_version//.*/}-dvc${{ matrix.dvc }}-base${{ matrix.base }}
           if [[ ${{ matrix.gpu }} == true ]]; then
-            echo ::set-output name=base::nvidia/cuda:${{ matrix.cuda }}-cudnn${{ matrix.cudnn }}-runtime-ubuntu${{ matrix.ubuntu }}
+            echo base=nvidia/cuda:${{ matrix.cuda }}-cudnn${{ matrix.cudnn }}-runtime-ubuntu${{ matrix.ubuntu }} >> $GITHUB_OUTPUT
             tag=${tag}-gpu
           else
-            echo ::set-output name=base::ubuntu:${{ matrix.ubuntu }}
+            echo base=ubuntu:${{ matrix.ubuntu }} >> $GITHUB_OUTPUT
           fi
 
           TAGS="$(
@@ -71,7 +71,7 @@ jobs:
               echo "${registry}/cml:${tag}"
             done | head -c-1
           )"
-          echo ::set-output name=tags::"${TAGS//$'\n'/'%0A'}"
+          echo tags="${TAGS//$'\n'/'%0A'}" >> $GITHUB_OUTPUT
       - uses: docker/setup-buildx-action@v1
       - uses: actions/cache@v3
         with:
@@ -94,8 +94,9 @@ jobs:
       - uses: docker/build-push-action@v2
         with:
           push:
-            ${{ inputs.release || github.event_name == 'push' || github.event_name == 'schedule'
-            || github.event_name == 'workflow_dispatch' }}
+            ${{ inputs.release || github.event_name == 'push' ||
+            github.event_name == 'schedule' || github.event_name ==
+            'workflow_dispatch' }}
           context: ./
           file: ./Dockerfile
           tags: |


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands