### PR TITLE
Rename `--token` to `--driver-token`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,11 +31,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: >
-          gh release create
-          --target ${{ github.event.pull_request.merge_commit_sha }}
-          {--title=CML\ ,}$(basename ${{ github.head_ref }})
-          --generate-notes
-          --draft
+          gh release create --target ${{
+          github.event.pull_request.merge_commit_sha }} {--title=CML\
+          ,}$(basename ${{ github.head_ref }}) --generate-notes --draft
         env:
           GITHUB_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN }}
   package:

--- a/README.md
+++ b/README.md
@@ -637,6 +637,7 @@ These are some example projects using CML.
 - [CML with Tensorboard](https://github.com/iterative-test/cml-example-tensorboard)
 - [CML with a small EC2 instance](https://github.com/iterative-test/cml-example-cloud)
   :key:
-- [CML with EC2 GPU](https://github.com/iterative-test/cml-example-cloud-gpu) :key:
+- [CML with EC2 GPU](https://github.com/iterative-test/cml-example-cloud-gpu)
+  :key:
 
 :key: needs a [PAT](#environment-variables).

--- a/bin/cml.js
+++ b/bin/cml.js
@@ -159,7 +159,7 @@ const handleError = (message, error) => {
             type: 'string',
             alias: 'token',
             defaultDescription: 'infer from the environment',
-            description: 'Driver personal access token',
+            description: 'CI driver personal/project access token (PAT)',
             group: 'Global Options:'
           }
         })

--- a/bin/cml.js
+++ b/bin/cml.js
@@ -12,6 +12,7 @@ const CML = require('../src/cml').default;
 const { jitsuEventPayload, send } = require('../src/analytics');
 
 const aliasLegacyEnvironmentVariables = () => {
+  // Remap environment variable prefixes so e.g. CML_COMMAND_OPTION be
   const legacyEnvironmentPrefixes = {
     CML_CI: 'CML',
     CML_PUBLISH: 'CML',
@@ -19,6 +20,9 @@ const aliasLegacyEnvironmentVariables = () => {
     CML_SEND_COMMENT: 'CML',
     CML_SEND_GITHUB_CHECK: 'CML',
     CML_TENSORBOARD_DEV: 'CML',
+    // Remap environment variable prefixes so e.g. CML_COMMAND_OPTION becomes an
+    // an alias for CML_OPTION, regardless of the command it't referring to.
+    // See also https://github.com/yargs/yargs/issues/873#issuecomment-917441475
     CML_ASSET: 'CML',
     CML_CHECK: 'CML',
     CML_COMMENT: 'CML',

--- a/bin/cml.js
+++ b/bin/cml.js
@@ -3,6 +3,7 @@
 const { basename } = require('path');
 const { pseudoexec } = require('pseudoexec');
 
+const kebabcaseKeys = require('kebabcase-keys');
 const which = require('which');
 const winston = require('winston');
 const yargs = require('yargs');
@@ -132,35 +133,37 @@ const handleError = (message, error) => {
 
   try {
     await yargs
-      .options({
-        log: {
-          type: 'string',
-          description: 'Logging verbosity',
-          choices: ['error', 'warn', 'info', 'debug'],
-          default: 'info',
-          group: 'Global Options:'
-        },
-        driver: {
-          type: 'string',
-          choices: ['github', 'gitlab', 'bitbucket'],
-          defaultDescription: 'infer from the environment',
-          description: 'Git provider where the repository is hosted',
-          group: 'Global Options:'
-        },
-        repo: {
-          type: 'string',
-          defaultDescription: 'infer from the environment',
-          description: 'Repository URL or slug',
-          group: 'Global Options:'
-        },
-        driverToken: {
-          type: 'string',
-          alias: 'token',
-          defaultDescription: 'infer from the environment',
-          description: 'Driver personal access token',
-          group: 'Global Options:'
-        }
-      })
+      .options(
+        kebabcaseKeys({
+          log: {
+            type: 'string',
+            description: 'Logging verbosity',
+            choices: ['error', 'warn', 'info', 'debug'],
+            default: 'info',
+            group: 'Global Options:'
+          },
+          driver: {
+            type: 'string',
+            choices: ['github', 'gitlab', 'bitbucket'],
+            defaultDescription: 'infer from the environment',
+            description: 'Git provider where the repository is hosted',
+            group: 'Global Options:'
+          },
+          repo: {
+            type: 'string',
+            defaultDescription: 'infer from the environment',
+            description: 'Repository URL or slug',
+            group: 'Global Options:'
+          },
+          driverToken: {
+            type: 'string',
+            alias: 'token',
+            defaultDescription: 'infer from the environment',
+            description: 'Driver personal access token',
+            group: 'Global Options:'
+          }
+        })
+      )
       .global('version', false)
       .group('help', 'Global Options:')
       .fail(handleError)

--- a/bin/cml.js
+++ b/bin/cml.js
@@ -12,7 +12,6 @@ const CML = require('../src/cml').default;
 const { jitsuEventPayload, send } = require('../src/analytics');
 
 const aliasLegacyEnvironmentVariables = () => {
-  // Remap environment variable prefixes so e.g. CML_COMMAND_OPTION be
   const legacyEnvironmentPrefixes = {
     CML_CI: 'CML',
     CML_PUBLISH: 'CML',

--- a/bin/cml.js
+++ b/bin/cml.js
@@ -12,12 +12,20 @@ const { jitsuEventPayload, send } = require('../src/analytics');
 
 const aliasLegacyEnvironmentVariables = () => {
   const legacyEnvironmentPrefixes = {
-    CML_CI: 'CML_REPO',
-    CML_PUBLISH: 'CML_ASSET',
-    CML_RERUN_WORKFLOW: 'CML_WORKFLOW',
-    CML_SEND_COMMENT: 'CML_COMMENT',
-    CML_SEND_GITHUB_CHECK: 'CML_CHECK',
-    CML_TENSORBOARD_DEV: 'CML_TENSORBOARD'
+    CML_CI: 'CML',
+    CML_PUBLISH: 'CML',
+    CML_RERUN_WORKFLOW: 'CML',
+    CML_SEND_COMMENT: 'CML',
+    CML_SEND_GITHUB_CHECK: 'CML',
+    CML_TENSORBOARD_DEV: 'CML',
+    CML_ASSET: 'CML',
+    CML_CHECK: 'CML',
+    CML_COMMENT: 'CML',
+    CML_PR: 'CML',
+    CML_REPO: 'CML',
+    CML_RUNNER: 'CML',
+    CML_TENSORBOARD: 'CML',
+    CML_WORKFLOW: 'CML'
   };
 
   for (const [oldPrefix, newPrefix] of Object.entries(
@@ -124,7 +132,6 @@ const handleError = (message, error) => {
 
   try {
     await yargs
-      .env('CML')
       .options({
         log: {
           type: 'string',
@@ -146,10 +153,11 @@ const handleError = (message, error) => {
           description: 'Repository URL or slug',
           group: 'Global Options:'
         },
-        token: {
+        driverToken: {
           type: 'string',
+          alias: 'token',
           defaultDescription: 'infer from the environment',
-          description: 'Personal access token',
+          description: 'Driver personal access token',
           group: 'Global Options:'
         }
       })

--- a/bin/cml.test.js
+++ b/bin/cml.test.js
@@ -25,7 +25,7 @@ describe('command-line interface tests', () => {
                                                                           environment]
         --repo                   Repository URL or slug
                                         [string] [default: infer from the environment]
-        --driver-token, --token  Driver personal access token
+        --driver-token, --token  CI driver personal/project access token (PAT)
                                         [string] [default: infer from the environment]
         --help                   Show help                                   [boolean]
 

--- a/bin/cml.test.js
+++ b/bin/cml.test.js
@@ -18,14 +18,16 @@ describe('command-line interface tests', () => {
         cml.js ci                 Prepare Git repository for CML operations
 
       Global Options:
-        --log     Logging verbosity
+        --log                   Logging verbosity
                 [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
-        --driver  Git provider where the repository is hosted
+        --driver                Git provider where the repository is hosted
           [string] [choices: \\"github\\", \\"gitlab\\", \\"bitbucket\\"] [default: infer from the
                                                                           environment]
-        --repo    Repository URL or slug[string] [default: infer from the environment]
-        --token   Personal access token [string] [default: infer from the environment]
-        --help    Show help                                                  [boolean]
+        --repo                  Repository URL or slug
+                                        [string] [default: infer from the environment]
+        --driverToken, --token  Driver personal access token
+                                        [string] [default: infer from the environment]
+        --help                  Show help                                    [boolean]
 
       Options:
         --version  Show version number                                       [boolean]"

--- a/bin/cml.test.js
+++ b/bin/cml.test.js
@@ -18,16 +18,16 @@ describe('command-line interface tests', () => {
         cml.js ci                 Prepare Git repository for CML operations
 
       Global Options:
-        --log                   Logging verbosity
+        --log                    Logging verbosity
                 [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
-        --driver                Git provider where the repository is hosted
+        --driver                 Git provider where the repository is hosted
           [string] [choices: \\"github\\", \\"gitlab\\", \\"bitbucket\\"] [default: infer from the
                                                                           environment]
-        --repo                  Repository URL or slug
+        --repo                   Repository URL or slug
                                         [string] [default: infer from the environment]
-        --driverToken, --token  Driver personal access token
+        --driver-token, --token  Driver personal access token
                                         [string] [default: infer from the environment]
-        --help                  Show help                                    [boolean]
+        --help                   Show help                                   [boolean]
 
       Options:
         --version  Show version number                                       [boolean]"

--- a/bin/cml/asset/publish.js
+++ b/bin/cml/asset/publish.js
@@ -28,7 +28,7 @@ exports.handler = async (opts) => {
 
 exports.builder = (yargs) =>
   yargs
-    .env('CML_ASSET')
+    .env('CML')
     .option('options', { default: exports.options, hidden: true })
     .options(exports.options);
 

--- a/bin/cml/asset/publish.test.js
+++ b/bin/cml/asset/publish.test.js
@@ -8,17 +8,17 @@ describe('CML cli test', () => {
       "cml.js publish <asset>
 
       Global Options:
-            --log                   Logging verbosity
+            --log                    Logging verbosity
                 [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
-            --driver                Git provider where the repository is hosted
+            --driver                 Git provider where the repository is hosted
           [string] [choices: \\"github\\", \\"gitlab\\", \\"bitbucket\\"] [default: infer from the
                                                                           environment]
-            --repo                  Specifies the repo to be used. If not specified is
-                                    extracted from the CI ENV.
+            --repo                   Specifies the repo to be used. If not specified
+                                     is extracted from the CI ENV.
                                         [string] [default: infer from the environment]
-            --driverToken, --token  Driver personal access token
+            --driver-token, --token  Driver personal access token
                                         [string] [default: infer from the environment]
-            --help                  Show help                                [boolean]
+            --help                   Show help                               [boolean]
 
       Options:
             --md         Output in markdown format [title || name](url)      [boolean]

--- a/bin/cml/asset/publish.test.js
+++ b/bin/cml/asset/publish.test.js
@@ -8,16 +8,17 @@ describe('CML cli test', () => {
       "cml.js publish <asset>
 
       Global Options:
-            --log     Logging verbosity
+            --log                   Logging verbosity
                 [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
-            --driver  Git provider where the repository is hosted
+            --driver                Git provider where the repository is hosted
           [string] [choices: \\"github\\", \\"gitlab\\", \\"bitbucket\\"] [default: infer from the
                                                                           environment]
-            --repo    Specifies the repo to be used. If not specified is extracted
-                      from the CI ENV.  [string] [default: infer from the environment]
-            --token   Personal access token
+            --repo                  Specifies the repo to be used. If not specified is
+                                    extracted from the CI ENV.
                                         [string] [default: infer from the environment]
-            --help    Show help                                              [boolean]
+            --driverToken, --token  Driver personal access token
+                                        [string] [default: infer from the environment]
+            --help                  Show help                                [boolean]
 
       Options:
             --md         Output in markdown format [title || name](url)      [boolean]

--- a/bin/cml/asset/publish.test.js
+++ b/bin/cml/asset/publish.test.js
@@ -16,7 +16,7 @@ describe('CML cli test', () => {
             --repo                   Specifies the repo to be used. If not specified
                                      is extracted from the CI ENV.
                                         [string] [default: infer from the environment]
-            --driver-token, --token  Driver personal access token
+            --driver-token, --token  CI driver personal/project access token (PAT)
                                         [string] [default: infer from the environment]
             --help                   Show help                               [boolean]
 

--- a/bin/cml/check/create.js
+++ b/bin/cml/check/create.js
@@ -15,7 +15,7 @@ exports.handler = async (opts) => {
 
 exports.builder = (yargs) =>
   yargs
-    .env('CML_CHECK')
+    .env('CML')
     .option('options', { default: exports.options, hidden: true })
     .options(exports.options);
 

--- a/bin/cml/check/create.test.js
+++ b/bin/cml/check/create.test.js
@@ -8,17 +8,17 @@ describe('CML e2e', () => {
       "cml.js send-github-check <markdown file>
 
       Global Options:
-        --log                   Logging verbosity
+        --log                    Logging verbosity
                 [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
-        --driver                Git provider where the repository is hosted
+        --driver                 Git provider where the repository is hosted
           [string] [choices: \\"github\\", \\"gitlab\\", \\"bitbucket\\"] [default: infer from the
                                                                           environment]
-        --repo                  Repository URL or slug
+        --repo                   Repository URL or slug
                                         [string] [default: infer from the environment]
-        --driverToken, --token  GITHUB_TOKEN or Github App token. Personal access
-                                token won't work
+        --driver-token, --token  GITHUB_TOKEN or Github App token. Personal access
+                                 token won't work
                                         [string] [default: infer from the environment]
-        --help                  Show help                                    [boolean]
+        --help                   Show help                                   [boolean]
 
       Options:
         --commit-sha, --head-sha  Commit SHA linked to this comment

--- a/bin/cml/check/create.test.js
+++ b/bin/cml/check/create.test.js
@@ -8,15 +8,17 @@ describe('CML e2e', () => {
       "cml.js send-github-check <markdown file>
 
       Global Options:
-        --log     Logging verbosity
+        --log                   Logging verbosity
                 [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
-        --driver  Git provider where the repository is hosted
+        --driver                Git provider where the repository is hosted
           [string] [choices: \\"github\\", \\"gitlab\\", \\"bitbucket\\"] [default: infer from the
                                                                           environment]
-        --repo    Repository URL or slug[string] [default: infer from the environment]
-        --token   GITHUB_TOKEN or Github App token. Personal access token won't work
+        --repo                  Repository URL or slug
                                         [string] [default: infer from the environment]
-        --help    Show help                                                  [boolean]
+        --driverToken, --token  GITHUB_TOKEN or Github App token. Personal access
+                                token won't work
+                                        [string] [default: infer from the environment]
+        --help                  Show help                                    [boolean]
 
       Options:
         --commit-sha, --head-sha  Commit SHA linked to this comment

--- a/bin/cml/comment/create.js
+++ b/bin/cml/comment/create.js
@@ -13,7 +13,7 @@ exports.handler = async (opts) => {
 
 exports.builder = (yargs) =>
   yargs
-    .env('CML_COMMENT')
+    .env('CML')
     .option('options', { default: exports.options, hidden: true })
     .options(exports.options);
 

--- a/bin/cml/comment/create.test.js
+++ b/bin/cml/comment/create.test.js
@@ -7,14 +7,16 @@ describe('Comment integration tests', () => {
       "cml.js send-comment <markdown file>
 
       Global Options:
-        --log     Logging verbosity
+        --log                   Logging verbosity
                 [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
-        --driver  Git provider where the repository is hosted
+        --driver                Git provider where the repository is hosted
           [string] [choices: \\"github\\", \\"gitlab\\", \\"bitbucket\\"] [default: infer from the
                                                                           environment]
-        --repo    Repository URL or slug[string] [default: infer from the environment]
-        --token   Personal access token [string] [default: infer from the environment]
-        --help    Show help                                                  [boolean]
+        --repo                  Repository URL or slug
+                                        [string] [default: infer from the environment]
+        --driverToken, --token  Driver personal access token
+                                        [string] [default: infer from the environment]
+        --help                  Show help                                    [boolean]
 
       Options:
         --pr                        Post to an existing PR/MR associated with the

--- a/bin/cml/comment/create.test.js
+++ b/bin/cml/comment/create.test.js
@@ -14,7 +14,7 @@ describe('Comment integration tests', () => {
                                                                           environment]
         --repo                   Repository URL or slug
                                         [string] [default: infer from the environment]
-        --driver-token, --token  Driver personal access token
+        --driver-token, --token  CI driver personal/project access token (PAT)
                                         [string] [default: infer from the environment]
         --help                   Show help                                   [boolean]
 

--- a/bin/cml/comment/create.test.js
+++ b/bin/cml/comment/create.test.js
@@ -7,16 +7,16 @@ describe('Comment integration tests', () => {
       "cml.js send-comment <markdown file>
 
       Global Options:
-        --log                   Logging verbosity
+        --log                    Logging verbosity
                 [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
-        --driver                Git provider where the repository is hosted
+        --driver                 Git provider where the repository is hosted
           [string] [choices: \\"github\\", \\"gitlab\\", \\"bitbucket\\"] [default: infer from the
                                                                           environment]
-        --repo                  Repository URL or slug
+        --repo                   Repository URL or slug
                                         [string] [default: infer from the environment]
-        --driverToken, --token  Driver personal access token
+        --driver-token, --token  Driver personal access token
                                         [string] [default: infer from the environment]
-        --help                  Show help                                    [boolean]
+        --help                   Show help                                   [boolean]
 
       Options:
         --pr                        Post to an existing PR/MR associated with the

--- a/bin/cml/pr.js
+++ b/bin/cml/pr.js
@@ -7,7 +7,7 @@ exports.builder = (yargs) =>
   yargs
     .commandDir('./pr', { exclude: /\.test\.js$/ })
     .recommendCommands()
-    .env('CML_PR')
+    .env('CML')
     .options(
       Object.fromEntries(
         Object.entries(options).map(([key, value]) => [

--- a/bin/cml/pr/create.e2e.test.js
+++ b/bin/cml/pr/create.e2e.test.js
@@ -22,7 +22,7 @@ describe('CML e2e', () => {
                                                                           environment]
         --repo                   Repository URL or slug
                                         [string] [default: infer from the environment]
-        --driver-token, --token  Driver personal access token
+        --driver-token, --token  CI driver personal/project access token (PAT)
                                         [string] [default: infer from the environment]
         --help                   Show help                                   [boolean]"
     `);

--- a/bin/cml/pr/create.e2e.test.js
+++ b/bin/cml/pr/create.e2e.test.js
@@ -15,16 +15,16 @@ describe('CML e2e', () => {
                                          https://cml.dev/doc/ref/pr
 
       Global Options:
-        --log                   Logging verbosity
+        --log                    Logging verbosity
                 [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
-        --driver                Git provider where the repository is hosted
+        --driver                 Git provider where the repository is hosted
           [string] [choices: \\"github\\", \\"gitlab\\", \\"bitbucket\\"] [default: infer from the
                                                                           environment]
-        --repo                  Repository URL or slug
+        --repo                   Repository URL or slug
                                         [string] [default: infer from the environment]
-        --driverToken, --token  Driver personal access token
+        --driver-token, --token  Driver personal access token
                                         [string] [default: infer from the environment]
-        --help                  Show help                                    [boolean]"
+        --help                   Show help                                   [boolean]"
     `);
   });
 });

--- a/bin/cml/pr/create.e2e.test.js
+++ b/bin/cml/pr/create.e2e.test.js
@@ -15,14 +15,16 @@ describe('CML e2e', () => {
                                          https://cml.dev/doc/ref/pr
 
       Global Options:
-        --log     Logging verbosity
+        --log                   Logging verbosity
                 [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
-        --driver  Git provider where the repository is hosted
+        --driver                Git provider where the repository is hosted
           [string] [choices: \\"github\\", \\"gitlab\\", \\"bitbucket\\"] [default: infer from the
                                                                           environment]
-        --repo    Repository URL or slug[string] [default: infer from the environment]
-        --token   Personal access token [string] [default: infer from the environment]
-        --help    Show help                                                  [boolean]"
+        --repo                  Repository URL or slug
+                                        [string] [default: infer from the environment]
+        --driverToken, --token  Driver personal access token
+                                        [string] [default: infer from the environment]
+        --help                  Show help                                    [boolean]"
     `);
   });
 });

--- a/bin/cml/pr/create.js
+++ b/bin/cml/pr/create.js
@@ -20,7 +20,7 @@ exports.handler = async (opts) => {
 
 exports.builder = (yargs) =>
   yargs
-    .env('CML_PR')
+    .env('CML')
     .option('options', { default: exports.options, hidden: true })
     .options(exports.options);
 

--- a/bin/cml/repo/prepare.js
+++ b/bin/cml/repo/prepare.js
@@ -15,7 +15,7 @@ exports.handler = async (opts) => {
 
 exports.builder = (yargs) =>
   yargs
-    .env('CML_REPO')
+    .env('CML')
     .option('options', { default: exports.options, hidden: true })
     .options(exports.options);
 

--- a/bin/cml/repo/prepare.test.js
+++ b/bin/cml/repo/prepare.test.js
@@ -10,14 +10,16 @@ describe('CML e2e', () => {
       Prepare Git repository for CML operations
 
       Global Options:
-        --log     Logging verbosity
+        --log                   Logging verbosity
                 [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
-        --driver  Git provider where the repository is hosted
+        --driver                Git provider where the repository is hosted
           [string] [choices: \\"github\\", \\"gitlab\\", \\"bitbucket\\"] [default: infer from the
                                                                           environment]
-        --repo    Repository URL or slug[string] [default: infer from the environment]
-        --token   Personal access token [string] [default: infer from the environment]
-        --help    Show help                                                  [boolean]
+        --repo                  Repository URL or slug
+                                        [string] [default: infer from the environment]
+        --driverToken, --token  Driver personal access token
+                                        [string] [default: infer from the environment]
+        --help                  Show help                                    [boolean]
 
       Options:
         --fetch-depth  Number of commits to fetch (use \`0\` for all branches & tags)

--- a/bin/cml/repo/prepare.test.js
+++ b/bin/cml/repo/prepare.test.js
@@ -10,16 +10,16 @@ describe('CML e2e', () => {
       Prepare Git repository for CML operations
 
       Global Options:
-        --log                   Logging verbosity
+        --log                    Logging verbosity
                 [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
-        --driver                Git provider where the repository is hosted
+        --driver                 Git provider where the repository is hosted
           [string] [choices: \\"github\\", \\"gitlab\\", \\"bitbucket\\"] [default: infer from the
                                                                           environment]
-        --repo                  Repository URL or slug
+        --repo                   Repository URL or slug
                                         [string] [default: infer from the environment]
-        --driverToken, --token  Driver personal access token
+        --driver-token, --token  Driver personal access token
                                         [string] [default: infer from the environment]
-        --help                  Show help                                    [boolean]
+        --help                   Show help                                   [boolean]
 
       Options:
         --fetch-depth  Number of commits to fetch (use \`0\` for all branches & tags)

--- a/bin/cml/repo/prepare.test.js
+++ b/bin/cml/repo/prepare.test.js
@@ -17,7 +17,7 @@ describe('CML e2e', () => {
                                                                           environment]
         --repo                   Repository URL or slug
                                         [string] [default: infer from the environment]
-        --driver-token, --token  Driver personal access token
+        --driver-token, --token  CI driver personal/project access token (PAT)
                                         [string] [default: infer from the environment]
         --help                   Show help                                   [boolean]
 

--- a/bin/cml/runner.js
+++ b/bin/cml/runner.js
@@ -7,7 +7,7 @@ exports.builder = (yargs) =>
   yargs
     .commandDir('./runner', { exclude: /\.test\.js$/ })
     .recommendCommands()
-    .env('CML_RUNNER')
+    .env('CML')
     .options(
       Object.fromEntries(
         Object.entries(options).map(([key, value]) => [

--- a/bin/cml/runner/launch.js
+++ b/bin/cml/runner/launch.js
@@ -421,7 +421,7 @@ exports.handler = async (opts) => {
 
 exports.builder = (yargs) =>
   yargs
-    .env('CML_RUNNER')
+    .env('CML')
     .option('options', { default: exports.options, hidden: true })
     .options(exports.options);
 

--- a/bin/cml/runner/launch.test.js
+++ b/bin/cml/runner/launch.test.js
@@ -14,14 +14,16 @@ describe('CML e2e', () => {
                               https://cml.dev/doc/ref/runner
 
       Global Options:
-        --log     Logging verbosity
+        --log                   Logging verbosity
                 [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
-        --driver  Git provider where the repository is hosted
+        --driver                Git provider where the repository is hosted
           [string] [choices: \\"github\\", \\"gitlab\\", \\"bitbucket\\"] [default: infer from the
                                                                           environment]
-        --repo    Repository URL or slug[string] [default: infer from the environment]
-        --token   Personal access token [string] [default: infer from the environment]
-        --help    Show help                                                  [boolean]"
+        --repo                  Repository URL or slug
+                                        [string] [default: infer from the environment]
+        --driverToken, --token  Driver personal access token
+                                        [string] [default: infer from the environment]
+        --help                  Show help                                    [boolean]"
     `);
   });
 });

--- a/bin/cml/runner/launch.test.js
+++ b/bin/cml/runner/launch.test.js
@@ -21,7 +21,7 @@ describe('CML e2e', () => {
                                                                           environment]
         --repo                   Repository URL or slug
                                         [string] [default: infer from the environment]
-        --driver-token, --token  Driver personal access token
+        --driver-token, --token  CI driver personal/project access token (PAT)
                                         [string] [default: infer from the environment]
         --help                   Show help                                   [boolean]"
     `);

--- a/bin/cml/runner/launch.test.js
+++ b/bin/cml/runner/launch.test.js
@@ -14,16 +14,16 @@ describe('CML e2e', () => {
                               https://cml.dev/doc/ref/runner
 
       Global Options:
-        --log                   Logging verbosity
+        --log                    Logging verbosity
                 [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
-        --driver                Git provider where the repository is hosted
+        --driver                 Git provider where the repository is hosted
           [string] [choices: \\"github\\", \\"gitlab\\", \\"bitbucket\\"] [default: infer from the
                                                                           environment]
-        --repo                  Repository URL or slug
+        --repo                   Repository URL or slug
                                         [string] [default: infer from the environment]
-        --driverToken, --token  Driver personal access token
+        --driver-token, --token  Driver personal access token
                                         [string] [default: infer from the environment]
-        --help                  Show help                                    [boolean]"
+        --help                   Show help                                   [boolean]"
     `);
   });
 });

--- a/bin/cml/tensorboard/connect.js
+++ b/bin/cml/tensorboard/connect.js
@@ -101,7 +101,7 @@ exports.handler = async (opts) => {
 
 exports.builder = (yargs) =>
   yargs
-    .env('CML_TENSORBOARD')
+    .env('CML')
     .option('options', { default: exports.options, hidden: true })
     .options(exports.options);
 

--- a/bin/cml/tensorboard/connect.test.js
+++ b/bin/cml/tensorboard/connect.test.js
@@ -8,16 +8,16 @@ describe('CML e2e', () => {
       "cml.js tensorboard-dev
 
       Global Options:
-            --log                   Logging verbosity
+            --log                    Logging verbosity
                 [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
-            --driver                Git provider where the repository is hosted
+            --driver                 Git provider where the repository is hosted
           [string] [choices: \\"github\\", \\"gitlab\\", \\"bitbucket\\"] [default: infer from the
                                                                           environment]
-            --repo                  Repository URL or slug
+            --repo                   Repository URL or slug
                                         [string] [default: infer from the environment]
-            --driverToken, --token  Driver personal access token
+            --driver-token, --token  Driver personal access token
                                         [string] [default: infer from the environment]
-            --help                  Show help                                [boolean]
+            --help                   Show help                               [boolean]
 
       Options:
         -c, --credentials  TensorBoard credentials as JSON, usually found at

--- a/bin/cml/tensorboard/connect.test.js
+++ b/bin/cml/tensorboard/connect.test.js
@@ -8,16 +8,16 @@ describe('CML e2e', () => {
       "cml.js tensorboard-dev
 
       Global Options:
-            --log     Logging verbosity
+            --log                   Logging verbosity
                 [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
-            --driver  Git provider where the repository is hosted
+            --driver                Git provider where the repository is hosted
           [string] [choices: \\"github\\", \\"gitlab\\", \\"bitbucket\\"] [default: infer from the
                                                                           environment]
-            --repo    Repository URL or slug
+            --repo                  Repository URL or slug
                                         [string] [default: infer from the environment]
-            --token   Personal access token
+            --driverToken, --token  Driver personal access token
                                         [string] [default: infer from the environment]
-            --help    Show help                                              [boolean]
+            --help                  Show help                                [boolean]
 
       Options:
         -c, --credentials  TensorBoard credentials as JSON, usually found at

--- a/bin/cml/tensorboard/connect.test.js
+++ b/bin/cml/tensorboard/connect.test.js
@@ -15,7 +15,7 @@ describe('CML e2e', () => {
                                                                           environment]
             --repo                   Repository URL or slug
                                         [string] [default: infer from the environment]
-            --driver-token, --token  Driver personal access token
+            --driver-token, --token  CI driver personal/project access token (PAT)
                                         [string] [default: infer from the environment]
             --help                   Show help                               [boolean]
 

--- a/bin/cml/workflow/rerun.js
+++ b/bin/cml/workflow/rerun.js
@@ -13,7 +13,7 @@ exports.handler = async (opts) => {
 
 exports.builder = (yargs) =>
   yargs
-    .env('CML_WORKFLOW')
+    .env('CML')
     .option('options', { default: exports.options, hidden: true })
     .options(exports.options);
 

--- a/bin/cml/workflow/rerun.test.js
+++ b/bin/cml/workflow/rerun.test.js
@@ -10,16 +10,16 @@ describe('CML e2e', () => {
       "cml.js rerun-workflow
 
       Global Options:
-        --log                   Logging verbosity
+        --log                    Logging verbosity
                 [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
-        --driver                Git provider where the repository is hosted
+        --driver                 Git provider where the repository is hosted
           [string] [choices: \\"github\\", \\"gitlab\\", \\"bitbucket\\"] [default: infer from the
                                                                           environment]
-        --repo                  Repository URL or slug
+        --repo                   Repository URL or slug
                                         [string] [default: infer from the environment]
-        --driverToken, --token  Driver personal access token
+        --driver-token, --token  Driver personal access token
                                         [string] [default: infer from the environment]
-        --help                  Show help                                    [boolean]
+        --help                   Show help                                   [boolean]
 
       Options:
         --id  Run identifier to be rerun                                      [string]"

--- a/bin/cml/workflow/rerun.test.js
+++ b/bin/cml/workflow/rerun.test.js
@@ -17,7 +17,7 @@ describe('CML e2e', () => {
                                                                           environment]
         --repo                   Repository URL or slug
                                         [string] [default: infer from the environment]
-        --driver-token, --token  Driver personal access token
+        --driver-token, --token  CI driver personal/project access token (PAT)
                                         [string] [default: infer from the environment]
         --help                   Show help                                   [boolean]
 

--- a/bin/cml/workflow/rerun.test.js
+++ b/bin/cml/workflow/rerun.test.js
@@ -10,14 +10,16 @@ describe('CML e2e', () => {
       "cml.js rerun-workflow
 
       Global Options:
-        --log     Logging verbosity
+        --log                   Logging verbosity
                 [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
-        --driver  Git provider where the repository is hosted
+        --driver                Git provider where the repository is hosted
           [string] [choices: \\"github\\", \\"gitlab\\", \\"bitbucket\\"] [default: infer from the
                                                                           environment]
-        --repo    Repository URL or slug[string] [default: infer from the environment]
-        --token   Personal access token [string] [default: infer from the environment]
-        --help    Show help                                                  [boolean]
+        --repo                  Repository URL or slug
+                                        [string] [default: infer from the environment]
+        --driverToken, --token  Driver personal access token
+                                        [string] [default: infer from the environment]
+        --help                  Show help                                    [boolean]
 
       Options:
         --id  Run identifier to be rerun                                      [string]"


### PR DESCRIPTION
Also fixes environment variable parsing by using a global `cml` prefix; previously, they were being silently ignored. Closes #763.