### PR TITLE
Replace comment target separator '#' with '/'.

### DIFF
--- a/bin/cml/comment/create.js
+++ b/bin/cml/comment/create.js
@@ -21,7 +21,7 @@ exports.options = kebabcaseKeys({
   target: {
     type: 'string',
     description:
-      'Comment type (`commit`, `pr`, `commit#f00bar`, `pr#42`, `issue#1337`),' +
+      'Comment type (`commit`, `pr`, `commit/f00bar`, `pr/42`, `issue/1337`),' +
       'default is automatic (`pr` but fallback to `commit`).'
   },
   pr: {

--- a/bin/cml/comment/create.test.js
+++ b/bin/cml/comment/create.test.js
@@ -17,8 +17,8 @@ describe('Comment integration tests', () => {
         --help    Show help                                                  [boolean]
 
       Options:
-        --target                    Comment type (\`commit\`, \`pr\`, \`commit#f00bar\`,
-                                    \`pr#42\`, \`issue#1337\`),default is automatic (\`pr\`
+        --target                    Comment type (\`commit\`, \`pr\`, \`commit/f00bar\`,
+                                    \`pr/42\`, \`issue/1337\`),default is automatic (\`pr\`
                                     but fallback to \`commit\`).                [string]
         --watch                     Watch for changes and automatically update the
                                     comment                                  [boolean]

--- a/src/commenttarget.js
+++ b/src/commenttarget.js
@@ -1,4 +1,4 @@
-const SEPARATOR = '#';
+const SEPARATOR = '/';
 
 async function parseCommentTarget(opts = {}) {
   const { commitSha: commit, pr, target, drv } = opts;
@@ -7,9 +7,9 @@ async function parseCommentTarget(opts = {}) {
   // Handle legacy comment target flags.
   if (commit) {
     drv.warn(
-      'cml: the --commitSha flag will be deprecated, please use --target="commit#<sha>"'
+      'cml: the --commitSha flag will be deprecated, please use --target="commit/<sha>"'
     );
-    commentTarget = `commit#${commit}`;
+    commentTarget = `commit${SEPARATOR}${commit}`;
   }
   if (pr) {
     drv.warn('cml: the --pr flag will be deprecated, please use --target="pr"');
@@ -41,7 +41,7 @@ async function parseCommentTarget(opts = {}) {
       }
       throw new Error(`PR for commit sha "${drv.sha}" not found`);
   }
-  // Handle qualified comment targets, e.g. 'issue#id'.
+  // Handle qualified comment targets, e.g. 'issue/id'.
   const separatorPos = commentTarget.indexOf(SEPARATOR);
   if (separatorPos === -1) {
     throw new Error(`comment target "${commentTarget}" could not be parsed`);

--- a/src/commenttarget.test.js
+++ b/src/commenttarget.test.js
@@ -7,21 +7,21 @@ describe('comment target tests', () => {
 
   test('qualified comment target: pr', async () => {
     const target = await parseCommentTarget({
-      target: 'pr#3'
+      target: 'pr/3'
     });
     expect(target).toEqual({ target: 'pr', prNumber: '3' });
   });
 
   test('qualified comment target: commit', async () => {
     const target = await parseCommentTarget({
-      target: 'commit#abcdefg'
+      target: 'commit/abcdefg'
     });
     expect(target).toEqual({ target: 'commit', commitSha: 'abcdefg' });
   });
 
   test('qualified comment target: issue', async () => {
     const target = await parseCommentTarget({
-      target: 'issue#3'
+      target: 'issue/3'
     });
     expect(target).toEqual({ target: 'issue', issueId: '3' });
   });
@@ -29,10 +29,10 @@ describe('comment target tests', () => {
   test('qualified comment target: unsupported', async () => {
     try {
       await parseCommentTarget({
-        target: 'unsupported#3'
+        target: 'unsupported/3'
       });
     } catch (error) {
-      expect(error.message).toBe('unsupported comment target "unsupported#3"');
+      expect(error.message).toBe('unsupported comment target "unsupported/3"');
     }
   });
 
@@ -41,7 +41,7 @@ describe('comment target tests', () => {
     const target = await parseCommentTarget({
       drv,
       commitSha: 'abcdefg',
-      target: 'issue#3' // target will be replaced with commit
+      target: 'issue/3' // target will be replaced with commit
     });
     expect(target).toEqual({ target: 'commit', commitSha: 'abcdefg' });
   });
@@ -55,7 +55,7 @@ describe('comment target tests', () => {
     const target = await parseCommentTarget({
       drv,
       pr: true,
-      target: 'issue#3' // target will be replaced
+      target: 'issue/3' // target will be replaced
     });
     expect(target).toEqual({ target: 'pr', prNumber: '4' });
   });
@@ -71,7 +71,7 @@ describe('comment target tests', () => {
     const target = await parseCommentTarget({
       drv,
       pr: true,
-      target: 'issue#3' // target will be replaced
+      target: 'issue/3' // target will be replaced
     });
     expect(target).toEqual({ target: 'pr', prNumber: '4' });
   });


### PR DESCRIPTION
This is addressing [this review](https://github.com/iterative/cml/pull/1228#discussion_r1042100146) of the comment target feature branch.