### PR TITLE
Add some debug logging for bitbucket and gitlab driver requests.

### DIFF
--- a/src/drivers/bitbucket_cloud.js
+++ b/src/drivers/bitbucket_cloud.js
@@ -483,6 +483,9 @@ class BitbucketCloud {
       headers['Content-Type'] = 'application/json';
 
     const requestUrl = url || `${api}${endpoint}`;
+    winston.debug(
+      `Bitbucket API request, method: ${method}, url: "${requestUrl}"`
+    );
     const response = await fetch(requestUrl, {
       method,
       headers,
@@ -495,6 +498,7 @@ class BitbucketCloud {
       : await response.text();
 
     if (!response.ok) {
+      winston.debug(`Response status is ${response.status}`);
       // Attempt to get additional context. We have observed two different error schemas
       // from BitBucket API responses: `{"error": {"message": "Error message"}}` and
       // `{"error": "Error message"}`, apart from plain text responses like `Bad Request`.

--- a/src/drivers/gitlab.js
+++ b/src/drivers/gitlab.js
@@ -488,6 +488,8 @@ class Gitlab {
     }
     if (!url) throw new Error('Gitlab API endpoint not found');
 
+    winston.debug(`Gitlab API request, method: ${method}, url: "${url}"`);
+
     const headers = { 'PRIVATE-TOKEN': token, Accept: 'application/json' };
     const response = await fetch(url, {
       method,
@@ -495,7 +497,10 @@ class Gitlab {
       body,
       agent: new ProxyAgent()
     });
-    if (response.status > 300) throw new Error(response.statusText);
+    if (!response.ok) {
+      winston.debug(`Response status is ${response.status}`);
+      throw new Error(response.statusText);
+    }
     if (raw) return response;
 
     return await response.json();


### PR DESCRIPTION
I think it make sense to add debug logging to aid in, well, debugging.
This is primarily inspired by #1278.