### PR TITLE
Skip failing github runner token e2e test.

### DIFF
--- a/src/drivers/github.e2e.test.js
+++ b/src/drivers/github.e2e.test.js
@@ -33,7 +33,8 @@ describe('Non Enviromental tests', () => {
     );
   });
 
-  test('Runner token', async () => {
+  // TODO: reenable the test once github test tokens are updated.
+  test.skip('Runner token', async () => {
     const output = await client.runnerToken();
     expect(output.length).toBe(29);
   });


### PR DESCRIPTION
The test is failing due to missing permissions in the test token we use for our integration tests. The
skipped test should be reenabled once that is fixed.