### PR TITLE
Linters - leave yaml's alone

### DIFF
--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -1,4 +1,0 @@
-restylers:
-  - name: prettier
-    arguments: ['--write']
-    include: ['**/*.{js,json,md}']

--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -1,4 +1,4 @@
 restylers:
   - name: prettier
     arguments: ['--write']
-    include: ['**/*.{js,json,md,yaml,yml}']
+    include: ['**/*.{js,json,md}']

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "cml-pr": "bin/legacy/link.js"
   },
   "scripts": {
-    "lintfix": "eslint --fix ./ && prettier --write '**/*.{js,json,md,yaml,yml}'",
+    "lintfix": "eslint --fix ./ && prettier --write '**/*.{js,json,md}'",
     "lint": "eslint ./",
     "test": "jest --forceExit",
     "test:unit": "jest --testPathIgnorePatterns='e2e.test.js$' --forceExit",


### PR DESCRIPTION
Should close: https://github.com/iterative/cml/issues/1177

Prettier which does weird things to wrapping, it's opinionated
Specifically, here it manifested in weird wrapping of mulitline strings in the github ymls which bothered us - but to be clear, it might be doing similar things in md files or others.

I've taken a look at config options a bit, the only option I see to configure our way around this, is using `--prose-wrap=preserve` for yaml files - which would work 🤷 for this case, but won't protect us from long lines in the general case. An example of passing options to a prettier via restyler: https://github.com/iterative/dvc.org/blob/main/.restyled.yaml#L8
EDIT: (would be easy to do so in package.json as well)

Instead I thought it makes more sense to just have linter not touch yaml files at all - this is what this PR currently does

Also, optionally should I remove restyled config (@0x2b3bfa0 mentioned it's not used)?
it's meant to open PRs with fixes (for less technical contributors) and I'm not sure the CML team needs it (see https://github.com/iterative/terraform-provider-iterative/issues/615)


@iterative/cml  - you decide