### PR TITLE
Patch `cml runner` idleness detection logic

### DIFF
--- a/bin/cml/runner/launch.js
+++ b/bin/cml/runner/launch.js
@@ -26,7 +26,7 @@ const shutdown = async (opts) => {
   const { name, tfResource, noRetry, reason, destroyDelay, watcher } = opts;
 
   const unregisterRunner = async () => {
-    if (!RUNNER) true;
+    if (!RUNNER) return true;
 
     try {
       winston.info(`Unregistering runner ${name}...`);

--- a/bin/cml/runner/launch.js
+++ b/bin/cml/runner/launch.js
@@ -283,7 +283,13 @@ const runLocal = async (opts) => {
       }
 
       if (log.status === 'job_ended') {
-        RUNNER_JOBS_RUNNING.pop();
+        // Runners can only take a job at a time, so the whole concept of using
+        // an array as a stack/counter (formerly RUNNER_JOBS_RUNNING.pop() on
+        // the line below) is a footgun. It should be just a boolean variable
+        // to hold the busy/idle status. To avoid too much refactoring, we just
+        // empty the array, so empty means idle and populated means busy.
+        RUNNER_JOBS_RUNNING.length = 0;
+
         if (single) await shutdown({ ...opts, reason: 'single job' });
       }
     }

--- a/bin/cml/runner/launch.js
+++ b/bin/cml/runner/launch.js
@@ -26,7 +26,7 @@ const shutdown = async (opts) => {
   const { name, tfResource, noRetry, reason, destroyDelay, watcher } = opts;
 
   const unregisterRunner = async () => {
-    if (!RUNNER) return;
+    if (!RUNNER) true;
 
     try {
       winston.info(`Unregistering runner ${name}...`);
@@ -40,7 +40,7 @@ const shutdown = async (opts) => {
       winston.error(`\tFailed: ${err.message}`);
     }
 
-    RUNNER && RUNNER.kill('SIGINT');
+    RUNNER.kill('SIGINT');
     winston.info('\tSuccess');
     return true;
   };

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -373,7 +373,7 @@ class Github {
 
         job.runner_id = jobRunnerId;
         if (job.runner_id === runnerId) break;
-        sleep(1);
+        await sleep(16);
       }
     }
 


### PR DESCRIPTION
~Will eventually close #1255; needs at least _anotter_ sleep/rinse/repeat cycle.~ Closes #1255 canceled jobs variant along with #1300, even though it's just a hack to mitigate a buffering issue described in https://github.com/iterative/cml/issues/1255#issuecomment-1367099955.

```
info: runner status {"date":"2022-12-29T23:12:03.719Z","repo":"...","status":"ready"}
info: Unregistering runner #...
warn:   Cancelling shutdown: Bad request - Runner "#" is still running a job"
info: runner status {"date":"2022-12-29T23:24:50.998Z","repo":"...","status":"job_ended","success":true}
info: runner status {"date":"2022-12-29T23:24:53.874Z","job":10357155026,"repo":"...","status":"job_started"}
info: runner status {"date":"2022-12-29T23:14:45.886Z","job":10357155026,"repo":"...","status":"job_started"}
```

### Minimal reproducible example

_Based on [`iterative/cml#main@45e32bd`](https://github.com/iterative/cml/commit/45e32bdbc9f001125b5f2c018b56f2e086648807)_

#### `.github/workflows/example.yml`
```yaml
on: workflow_dispatch
jobs:
  runner:
    runs-on: ubuntu-latest
    steps:
    - uses: actions/checkout@v3
    - run: >
        npx github:iterative/cml#45e32bd runner launch
        --labels=${{ github.run_id }}-${{ github.run_attempt }}
        --idle-timeout=60
      env:
        CML_TOKEN: ${{ secrets.CML_TOKEN }}
  job:
    strategy: # run two jobs serially on the same runner
      matrix:
        test: [1, 2]
      max-parallel: 1
    runs-on:
      - self-hosted
      - ${{ github.run_id }}-${{ github.run_attempt }}
    steps:
      - run: sleep 120 # more than --idle-timeout=60 above
 ```

#### Outcome

The `runner` job finishes prematurely with a `Failed: Bad request - Runner ... is still running a job` error message and the runner process is terminated before it finished the first job and can take the second job, thus leaving the latter queued forever and producing the following error on the user interface after a few minutes:

```
The self-hosted runner: ... lost communication with the server. Verify the machine is running and has a healthy network connection. Anything in your workflow that terminates the runner process, starves it for CPU/Memory, or blocks its network access can cause this error.
```