### PR TITLE
Add missing `await` and increase polling delay

### DIFF
--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -378,7 +378,7 @@ class Github {
 
         job.runner_id = jobRunnerId;
         if (job.runner_id === runnerId) break;
-        sleep(1);
+        await sleep(16);
       }
     }
 


### PR DESCRIPTION
> _“I was thinking of the immortal words of Socrates when he said... I drank what?”_

Mitigates some of the the rate limiting issues of #1255, although the upstream cause seems to be related to https://github.com/octokit/plugin-throttling.js/issues/454