### PR TITLE
Implement `cml runner launch --cloud-image`

### DIFF
--- a/bin/cml/runner/launch.js
+++ b/bin/cml/runner/launch.js
@@ -135,6 +135,7 @@ const runCloud = async (opts) => {
       cloudStartupScript: startupScript,
       cloudAwsSecurityGroup: awsSecurityGroup,
       cloudAwsSubnet: awsSubnet,
+      cloudImage: image,
       workdir
     } = opts;
 
@@ -171,6 +172,7 @@ const runCloud = async (opts) => {
       startupScript,
       awsSecurityGroup,
       awsSubnet,
+      image,
       dockerVolumes
     });
 
@@ -581,6 +583,11 @@ exports.options = kebabcaseKeys({
     default: '',
     description: 'Specifies the subnet to use within AWS',
     alias: 'cloud-aws-subnet-id'
+  },
+  cloudImage: {
+    type: 'string',
+    description: 'Custom machine/container image',
+    hidden: true
   },
   tpiVersion: {
     type: 'string',

--- a/src/terraform.js
+++ b/src/terraform.js
@@ -87,6 +87,7 @@ const iterativeCmlRunnerTpl = (opts = {}) => {
     resource: {
       iterative_cml_runner: {
         runner: {
+          ...(opts.image && { image: opts.image }),
           ...(opts.awsSecurityGroup && {
             aws_security_group: opts.awsSecurityGroup
           }),


### PR DESCRIPTION
Closes https://github.com/iterative/cml/issues/1285 and discord#cml/1057160051904753704 (wishful thinking, needs testing)

* Amazon Web Services: AMI name, like `iterative-cml` (potentially dangerous, allows overriding by a third party)
* Google Cloud: machine image families in the `project/family` format, like `ubuntu-os-cloud/ubuntu-2004-lts`
* Microsoft Azure: machine images in the `publisher:offer:sku:version` format, like `Canonical:UbuntuServer:18.04-LTS:latest`
* Kubernetes: valid [container image names](https://kubernetes.io/docs/concepts/containers/images/#image-names) like `ubuntu` or `ghcr.io/user/project:tag`