### PR TITLE
Fix rate limit issues in parallelized workflows

### DIFF
--- a/src/cml.js
+++ b/src/cml.js
@@ -387,7 +387,15 @@ class CML {
           log.job = parseId('job');
           log.pipeline = parseId('pipeline');
 
-          if (name && cloudSpot && this.driver === GITHUB) {
+          // GitHub API doesn’t seem to provide a straightforward way to get the
+          // job identifier from the runner logs, so we need to query several API
+          // endpoints to retrieve it. Due to several broken parts of our logic and
+          // some unexpected API responses, performing these queries may trigger API
+          // rate limits, causing the whole `cml` process to crash. Given that
+          // retrieving the job identifier is only useful for spot instance recovery
+          // (i.e. automated retryWorkflow), we can save ourselves all the hassle if
+          // —-cloud-spot is not set or —-driver is not GitHub.
+          if (cloudSpot && this.driver === GITHUB) {
             const { id: runnerId } = await this.runnerByName({ name });
             const { id } = await driver.runnerJob({ runnerId });
             log.job = id;

--- a/src/cml.js
+++ b/src/cml.js
@@ -357,7 +357,7 @@ class CML {
   }
 
   async parseRunnerLog(opts = {}) {
-    let { data, name } = opts;
+    let { data } = opts;
     if (!data) return [];
 
     data = data.toString('utf8');
@@ -387,11 +387,12 @@ class CML {
           log.job = parseId('job');
           log.pipeline = parseId('pipeline');
 
-          if (name && this.driver === GITHUB) {
-            const { id: runnerId } = await this.runnerByName({ name });
-            const { id } = await driver.runnerJob({ runnerId });
-            log.job = id;
-          }
+          // THE SOURCE OF ALL EVIL
+          // if (name && this.driver === GITHUB) {
+          //   const { id: runnerId } = await this.runnerByName({ name });
+          //   const { id } = await driver.runnerJob({ runnerId });
+          //   log.job = id;
+          // }
         }
 
         if (status === 'job_ended')

--- a/src/cml.js
+++ b/src/cml.js
@@ -357,7 +357,7 @@ class CML {
   }
 
   async parseRunnerLog(opts = {}) {
-    let { data } = opts;
+    let { data, name, cloudSpot } = opts;
     if (!data) return [];
 
     data = data.toString('utf8');
@@ -387,12 +387,11 @@ class CML {
           log.job = parseId('job');
           log.pipeline = parseId('pipeline');
 
-          // THE SOURCE OF ALL EVIL
-          // if (name && this.driver === GITHUB) {
-          //   const { id: runnerId } = await this.runnerByName({ name });
-          //   const { id } = await driver.runnerJob({ runnerId });
-          //   log.job = id;
-          // }
+          if (name && cloudSpot && this.driver === GITHUB) {
+            const { id: runnerId } = await this.runnerByName({ name });
+            const { id } = await driver.runnerJob({ runnerId });
+            log.job = id;
+          }
         }
 
         if (status === 'job_ended')

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -56,7 +56,7 @@ const octokit = (token, repo) => {
   const throttleHandler = (reason, offset) => async (retryAfter, options) => {
     if (options.request.retryCount <= 5) {
       winston.info(
-        `Retrying because of ${reason} after ${retryAfter + offset} seconds`
+        `Retrying because of ${reason} in ${retryAfter + offset} seconds`
       );
       await new Promise((resolve) => setTimeout(resolve, offset * 1000));
       return true;


### PR DESCRIPTION
Ready for feedback, needs more testing before merging. Hopefully closes #1255 once and for all. 😅 

# Follow-ups

## Report the API inconsistency below to GitHub Support

```
on: push
jobs:
  runner:
    runs-on: ubuntu-latest
    steps:
      - run: >
          curl --location https://github.com/actions/runner/releases/download/v2.299.1/actions-runner-linux-x64-2.299.1.tar.gz |
          tar --gzip --extract
      - run: >
          ./config.sh
          --unattended
          --name "$(uuidgen)"
          --url "https://github.com/$GITHUB_REPOSITORY"
          --token "$(gh api --jq=.token --method=POST /repos/$GITHUB_REPOSITORY/actions/runners/registration-token)"
        env:
          GH_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
      - run: >
          ./run.sh
        timeout-minutes: 10
  dummy:
    runs-on: self-hosted
    strategy:
      matrix:
        test: [1, 2]
    steps:
      - run: sleep 120
  test:
    runs-on: ubuntu-latest
    steps:
      - run: |
          while sleep 10; do
            run=$(gh run list --{json=,jq=.[0].}databaseId)
            job=$(gh run view $run --json=jobs --jq='.jobs[] | select(.name=="dummy (1)") | .databaseId')
            gh api /repos/$GITHUB_REPOSITORY/actions/jobs/$job
            date
          done
        env:
          GH_REPO: ${{ github.repository }}
          GH_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }} # ${{ github.token }}
```


## [Revisit](https://github.com/iterative/cml/pull/1299#discussion_r1059227378), revisit all the logic! 🔥 

The `cml runner` logic is flawed and very hard to test. We have to fix that.

# Impact

This pull request breaks automated workflow retries on GitHub, for e.g. spot instance termination or 35 day timeout limits. On the other hand, it fixes the rate limit issues caused by a chain of flawed logic and GitHub API responses.

## Issue 1

https://github.com/iterative/cml/blob/506e4e8d60e48e2ee4e99cfe9ff38ad6ec6a8f7f/src/drivers/github.js#L370-L382

Responses from [`actions.getJobForWorkflowRun`](https://octokit.github.io/rest.js/v19#actions-get-job-for-workflow-run) return `runner_id: 0` instead of the actual runner identifier, preventing the `while` loop from finishing:

```
GET /repos/$owner/$repo/actions/jobs/$owner/$repo - 200 in 453ms
```
```
request {
  method: 'GET',
  baseUrl: 'https://api.github.com',
  headers: {
    accept: 'application/vnd.github.v3+json',
    'user-agent': 'octokit-rest.js/18.0.0 octokit-core.js/3.6.0 Node.js/16.18.1 (linux; x64)'
  },
  mediaType: { format: '', previews: [] },
  request: {
    agent: ProxyAgent { promisifiedCallback: [Function (anonymous)] },
    hook: [Function: bound bound register]
  },
  url: '/repos/$owner/$repo$/actions/jobs/$job_id',
  owner: '$owner',
  repo: '$repo',
  job_id: $job_id
}
```
```
status: 200,
url: 'https://api.github.com/repos/$owner/$repo/actions/jobs/$owner/$repo',
headers: {
  'access-control-allow-origin': '*',
  'access-control-expose-headers': 'ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset',
  'cache-control': 'private, max-age=60, s-maxage=60',
  connection: 'close',
  'content-encoding': 'gzip',
  'content-security-policy': "default-src 'none'",
  'content-type': 'application/json; charset=utf-8',
  date: '$date',
  etag: '$etag',
  'referrer-policy': 'origin-when-cross-origin, strict-origin-when-cross-origin',
  server: 'GitHub.com',
  'strict-transport-security': 'max-age=31536000; includeSubdomains; preload',
  'transfer-encoding': 'chunked',
  vary: 'Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding, Accept, X-Requested-With',
  'x-accepted-oauth-scopes': '',
  'x-content-type-options': 'nosniff',
  'x-frame-options': 'deny',
  'x-github-api-version-selected': '2022-11-28',
  'x-github-media-type': 'github.v3; format=json',
  'x-github-request-id': '$request_id',
  'x-oauth-scopes': '$scopes',
  'x-ratelimit-limit': '5000',
  'x-ratelimit-remaining': '4084',
  'x-ratelimit-reset': '1672717625',
  'x-ratelimit-resource': 'core',
  'x-ratelimit-used': '916',
  'x-xss-protection': '0'
},
data: {
  id: $job_id,
  run_id: $run_id,
  workflow_name: '$workflow',
  head_branch: 'main',
  run_url: 'https://api.github.com/repos/$owner/$repo/actions/runs/$run_id',
  run_attempt: 7,
  node_id: '$node_id',
  head_sha: '$commit',
  url: 'https://api.github.com/repos/$owner/$repo/actions/jobs/$job_id',
  html_url: 'https://github.com/$owner/$repo/actions/runs/$run_id/jobs/$job_id_different',
  status: 'queued',
  conclusion: null,
  started_at: '$date',
  completed_at: null,
  name: '$job_name',
  steps: [],
  check_run_url: 'https://api.github.com/repos/$owner/$repo/check-runs/$job_id',
  labels: [ 'self-hosted' ],
  runner_id: 0,
  runner_name: '',
  runner_group_id: 0,
  runner_group_name: ''
}
```
