### PR TITLE
Add the sha of the the current commit to the watermark as the fragment of the watermark image url.

### DIFF
--- a/src/cml.js
+++ b/src/cml.js
@@ -276,7 +276,7 @@ class CML {
     let comment;
     const updatableComment = (comments) => {
       return comments.reverse().find(({ body }) => {
-        return watermark === null || watermark.isIn(body);
+        return !watermark || watermark.isIn(body);
       });
     };
 

--- a/src/cml.js
+++ b/src/cml.js
@@ -189,7 +189,7 @@ class CML {
           label: watermarkTitle,
           workflow: drv.workflowId,
           run: drv.runId,
-          sha: commitSha
+          sha: commitSha || (await this.triggerSha())
         });
 
     let userReport = testReport;

--- a/src/cml.js
+++ b/src/cml.js
@@ -21,10 +21,9 @@ const {
   preventcacheUri,
   waitForever
 } = require('./utils');
-
+const { Watermark } = require('./watermark');
 const { GITHUB_REPOSITORY, CI_PROJECT_URL, BITBUCKET_REPO_UUID } = process.env;
 
-const WATERMARK_IMAGE = 'https://cml.dev/watermark.png';
 const GIT_USER_NAME = 'Olivaw[bot]';
 const GIT_USER_EMAIL = 'olivaw@iterative.ai';
 const GIT_REMOTE = 'origin';
@@ -181,36 +180,16 @@ class CML {
     const drv = this.getDriver();
 
     if (rmWatermark && update)
-      throw new Error('watermarks are mandatory for updateable comments');
+      throw new Error('watermarks are mandatory for updatable comments');
 
     // Create the watermark.
-    const genWatermark = (opts = {}) => {
-      const { label = '', workflow, run } = opts;
-      // Replace {workflow} and {run} placeholders in label with actual values.
-      const lbl = label.replace('{workflow}', workflow).replace('{run}', run);
-
-      let title = `CML watermark ${lbl}`.trim();
-      // Github appears to escape underscores and asterisks in markdown content.
-      // Without escaping them, the watermark content in comments retrieved
-      // from github will not match the input.
-      const patterns = [
-        [/_/g, '\\_'], // underscore
-        [/\*/g, '\\*'], // asterisk
-        [/\[/g, '\\['], // opening square bracket
-        [/</g, '\\<'] // opening angle bracket
-      ];
-      title = patterns.reduce(
-        (label, pattern) => label.replace(pattern[0], pattern[1]),
-        title
-      );
-      return `![](${WATERMARK_IMAGE} "${title}")`;
-    };
     const watermark = rmWatermark
-      ? ''
-      : genWatermark({
+      ? null
+      : new Watermark({
           label: watermarkTitle,
           workflow: drv.workflowId,
-          run: drv.runId
+          run: drv.runId,
+          sha: commitSha
         });
 
     let userReport = testReport;
@@ -222,7 +201,10 @@ class CML {
       if (!watch) throw err;
     }
 
-    let report = `${userReport}\n\n${watermark}`;
+    let report = userReport;
+    if (watermark) {
+      report = watermark.appendTo(userReport);
+    }
 
     const publishLocalFiles = async (tree) => {
       const nodes = [];
@@ -294,7 +276,7 @@ class CML {
     let comment;
     const updatableComment = (comments) => {
       return comments.reverse().find(({ body }) => {
-        return body.includes(watermark);
+        return watermark === null || watermark.isIn(body);
       });
     };
 

--- a/src/watermark.js
+++ b/src/watermark.js
@@ -1,0 +1,65 @@
+const WATERMARK_IMAGE = 'https://cml.dev/watermark.png';
+
+class Watermark {
+  constructor(opts = {}) {
+    const { label = '', workflow, run, sha = false } = opts;
+    // Replace {workflow} and {run} placeholders in label with actual values.
+    this.label = label.replace('{workflow}', workflow).replace('{run}', run);
+
+    this.sha = sha;
+  }
+
+  // Appends the watermark (in markdown) to the report.
+  appendTo(report) {
+    return `${report}\n\n${this.toString()}`;
+  }
+
+  // Returns whether the watermark is present in the specified text.
+  // When checking for presence, the commit sha in the watermark is ignored.
+  isIn(text) {
+    const title = escapeRegExp(this.title);
+    const url = escapeRegExp(this.url({ sha: false }));
+    const pattern = `!\\[\\]\\(${url}#[0-9a-fA-F]+ "${title}"\\)`;
+    const re = new RegExp(pattern);
+    return re.test(text);
+  }
+
+  // String representation of the watermark.
+  toString() {
+    // Replace {workflow} and {run} placeholders in label with actual values.
+    return `![](${this.url()} "${this.title}")`;
+  }
+
+  get title() {
+    let title = `CML watermark ${this.label}`.trim();
+    // Github appears to escape underscores and asterisks in markdown content.
+    // Without escaping them, the watermark content in comments retrieved
+    // from github will not match the input.
+    const patterns = [
+      [/_/g, '\\_'], // underscore
+      [/\*/g, '\\*'], // asterisk
+      [/\[/g, '\\['], // opening square bracket
+      [/</g, '\\<'] // opening angle bracket
+    ];
+    title = patterns.reduce(
+      (label, pattern) => label.replace(pattern[0], pattern[1]),
+      title
+    );
+    return title;
+  }
+
+  url(opts = {}) {
+    const { sha = this.sha } = opts;
+    const watermarkUrl = new URL(WATERMARK_IMAGE);
+    if (sha) {
+      watermarkUrl.hash = sha;
+    }
+    return watermarkUrl.toString();
+  }
+}
+
+function escapeRegExp(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+module.exports = { Watermark };

--- a/src/watermark.test.js
+++ b/src/watermark.test.js
@@ -1,0 +1,107 @@
+const { Watermark } = require('../src/watermark');
+
+describe('watermark tests', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test('append watermark to report', async () => {
+    const watermark = new Watermark({
+      workflow: 'workflow-id',
+      run: 'run-id',
+      sha: 'deadbeef'
+    });
+    const report = watermark.appendTo('some report');
+    expect(report).toEqual(
+      'some report\n\n![](https://cml.dev/watermark.png#deadbeef "CML watermark")'
+    );
+  });
+
+  test('append watermark with label to report', async () => {
+    const watermark = new Watermark({
+      label: 'some-label',
+      workflow: 'workflow-id',
+      run: 'run-id',
+      sha: 'deadbeef'
+    });
+    const report = watermark.appendTo('some report');
+    expect(report).toEqual(
+      'some report\n\n![](https://cml.dev/watermark.png#deadbeef "CML watermark some-label")'
+    );
+  });
+
+  test('append watermark with workflow placeholder to report', async () => {
+    const watermark = new Watermark({
+      label: 'some-label-{workflow}',
+      workflow: 'workflow-id',
+      run: 'run-id',
+      sha: 'deadbeef'
+    });
+    const report = watermark.appendTo('some report');
+    expect(report).toEqual(
+      'some report\n\n![](https://cml.dev/watermark.png#deadbeef "CML watermark some-label-workflow-id")'
+    );
+  });
+
+  test('append watermark with run placeholder to report', async () => {
+    const watermark = new Watermark({
+      label: 'some-label-{run}',
+      workflow: 'workflow-id',
+      run: 'run-id',
+      sha: 'deadbeef'
+    });
+    const report = watermark.appendTo('some report');
+    expect(report).toEqual(
+      'some report\n\n![](https://cml.dev/watermark.png#deadbeef "CML watermark some-label-run-id")'
+    );
+  });
+
+  test('check for presence of the watermark in a report', async () => {
+    const watermark = new Watermark({
+      workflow: 'workflow-id',
+      run: 'run-id',
+      sha: 'deadbeef'
+    });
+    const report = watermark.appendTo('some report');
+    expect(watermark.isIn(report)).toEqual(true);
+  });
+
+  test('check for presence of the watermark in a report, different sha', async () => {
+    const watermark = new Watermark({
+      label: 'some-label-{run}',
+      run: 'run-id',
+      sha: 'deadbeef'
+    });
+    const report = watermark.appendTo('some report');
+
+    // Watermark with a different sha, created by a CI run on
+    // a different HEAD commit.
+    const newWatermark = new Watermark({
+      label: 'some-label-{run}',
+      run: 'run-id',
+      sha: 'abcd'
+    });
+
+    expect(newWatermark.isIn(report)).toEqual(true);
+  });
+
+  test('check for watermark mismatch', async () => {
+    const watermark = new Watermark({
+      label: 'some-label-{workflow}',
+      workflow: 'workflow-id',
+      sha: 'deadbeef'
+    });
+    const report = watermark.appendTo('some report');
+
+    // Watermark with a different sha and different
+    // workflow.
+    const newWatermark = new Watermark({
+      workflow: 'different-workflow-id',
+      label: 'some-label-{workflow}',
+      run: 'run-id',
+      sha: 'abcd'
+    });
+
+    expect(newWatermark.isIn(report)).toEqual(false);
+  });
+});

--- a/src/watermark.test.js
+++ b/src/watermark.test.js
@@ -68,7 +68,7 @@ describe('watermark tests', () => {
 
   test('check for presence of the watermark with special chars in a report', async () => {
     const watermark = new Watermark({
-      label: 'custom_1-vm',
+      label: 'custom_1[*]-vm',
       workflow: 'workflow-id',
       run: 'run-id',
       sha: 'deadbeef'

--- a/src/watermark.test.js
+++ b/src/watermark.test.js
@@ -66,6 +66,17 @@ describe('watermark tests', () => {
     expect(watermark.isIn(report)).toEqual(true);
   });
 
+  test('check for presence of the watermark with special chars in a report', async () => {
+    const watermark = new Watermark({
+      label: 'custom_1-vm',
+      workflow: 'workflow-id',
+      run: 'run-id',
+      sha: 'deadbeef'
+    });
+    const report = watermark.appendTo('some report');
+    expect(watermark.isIn(report)).toEqual(true);
+  });
+
   test('check for presence of the watermark in a report, different sha', async () => {
     const watermark = new Watermark({
       label: 'some-label-{run}',


### PR DESCRIPTION
This PR also updates the way updatable comments are determined - the matcher should ignore the sha in
the watermark.

This PR supercedes #1304.