### PR TITLE
Stop pushing to docker.io/dvcorg

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -60,7 +60,7 @@ jobs:
           fi
 
           TAGS="$(
-            for registry in docker.io/{dvcorg,iterativeai} ghcr.io/iterative; do
+            for registry in docker.io/iterativeai ghcr.io/iterative; do
               if [[ "${{ matrix.latest }}" == "true" ]]; then
                 if [[ "${{ matrix.gpu }}" == "true" ]]; then
                   echo "${registry}/cml:latest-gpu"


### PR DESCRIPTION
Deprecated as per an internal notice; we'll see if any users still rely on it by means of [fault-induced telemetry](https://github.com/iterative/cml/pull/1003#issuecomment-1124246143). 😸 