### PR TITLE
Use default token to upload release artifacts

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -96,8 +96,6 @@ jobs:
   packages:
     needs: [lint, test, test-os]
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -96,6 +96,8 @@ jobs:
   packages:
     needs: [lint, test, test-os]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
         with:
@@ -118,11 +120,9 @@ jobs:
           cp build/cml-macos{-x64,}
       - if: inputs.release
         run:
-          # wait for the release draftbefore uploading artifacts; blame GitHub API for eventual inconsistency?
-          until gh release view "$GITHUB_REF_NAME"; do sleep 10; done
           find build -type f | xargs gh release upload "$GITHUB_REF_NAME"
         env:
-          GITHUB_TOKEN: ${{ secrets.TEST_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
   images:
     needs: packages
     secrets: inherit

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -119,8 +119,8 @@ jobs:
       - if: inputs.release
         run:
           # wait for the release draftbefore uploading artifacts; blame GitHub API for eventual inconsistency?
-          until gh release view $(basename ${{ github.head_ref }}); do sleep 10; done
-          find build -type f | xargs gh release upload $(basename ${{ github.head_ref }})
+          until gh release view "$GITHUB_REF_NAME"; do sleep 10; done
+          find build -type f | xargs gh release upload "$GITHUB_REF_NAME"
         env:
           GITHUB_TOKEN: ${{ secrets.TEST_GITHUB_TOKEN }}
   images:

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -118,8 +118,9 @@ jobs:
           cp build/cml-macos{-x64,}
       - if: inputs.release
         run:
-          find build -type f | xargs gh release upload $(basename ${{
-          github.head_ref }})
+          # wait for the release draftbefore uploading artifacts; blame GitHub API for eventual inconsistency?
+          until gh release view $(basename ${{ github.head_ref }}); do sleep 10; done
+          find build -type f | xargs gh release upload $(basename ${{ github.head_ref }})
         env:
           GITHUB_TOKEN: ${{ secrets.TEST_GITHUB_TOKEN }}
   images:


### PR DESCRIPTION
[3936080711](https://github.com/iterative/cml/actions/runs/3936080711/jobs/6732339721) was failing because `secrets.TEST_GITHUB_TOKEN` no longer (?) had enough permissions to upload release artifacts and errored with `release not found`