### PR TITLE
Fix `yargs` global options bypassing strict checks

### DIFF
--- a/bin/cml.js
+++ b/bin/cml.js
@@ -13,23 +13,12 @@ const { jitsuEventPayload, send } = require('../src/analytics');
 
 const aliasLegacyEnvironmentVariables = () => {
   const legacyEnvironmentPrefixes = {
-    CML_CI: 'CML',
-    CML_PUBLISH: 'CML',
-    CML_RERUN_WORKFLOW: 'CML',
-    CML_SEND_COMMENT: 'CML',
-    CML_SEND_GITHUB_CHECK: 'CML',
-    CML_TENSORBOARD_DEV: 'CML',
-    // Remap environment variable prefixes so e.g. CML_COMMAND_OPTION becomes an
-    // an alias for CML_OPTION, regardless of the command it't referring to.
-    // See also https://github.com/yargs/yargs/issues/873#issuecomment-917441475
-    CML_ASSET: 'CML',
-    CML_CHECK: 'CML',
-    CML_COMMENT: 'CML',
-    CML_PR: 'CML',
-    CML_REPO: 'CML',
-    CML_RUNNER: 'CML',
-    CML_TENSORBOARD: 'CML',
-    CML_WORKFLOW: 'CML'
+    CML_CI: 'CML_REPO',
+    CML_PUBLISH: 'CML_ASSET',
+    CML_RERUN_WORKFLOW: 'CML_WORKFLOW',
+    CML_SEND_COMMENT: 'CML_COMMENT',
+    CML_SEND_GITHUB_CHECK: 'CML_CHECK',
+    CML_TENSORBOARD_DEV: 'CML_TENSORBOARD'
   };
 
   for (const [oldPrefix, newPrefix] of Object.entries(
@@ -40,6 +29,24 @@ const aliasLegacyEnvironmentVariables = () => {
         process.env[key.replace(oldPrefix, newPrefix)] = process.env[key];
     }
   }
+
+  // Remap environment variable prefixes so e.g. CML_OPTION global options become
+  // an alias for CML_COMMAND_OPTION, to be interpreted by the appropriate subcommands.
+  // See also https://github.com/yargs/yargs/issues/873#issuecomment-917441475
+  for (const globalOption of ['DRIVER', 'DRIVER_TOKEN', 'LOG', 'REPO', 'TOKEN'])
+    for (const subcommand of [
+      'ASSET',
+      'CHECK',
+      'COMMENT',
+      'PR',
+      'REPO',
+      'RUNNER',
+      'TENSORBOARD',
+      'WORKFLOW'
+    ])
+      if (process.env[`CML_${globalOption}`] !== undefined)
+        process.env[`CML_${subcommand}_${globalOption}`] =
+          process.env[`CML_${globalOption}`];
 
   const legacyEnvironmentVariables = {
     TB_CREDENTIALS: 'CML_TENSORBOARD_CREDENTIALS',

--- a/bin/cml/asset/publish.js
+++ b/bin/cml/asset/publish.js
@@ -28,7 +28,7 @@ exports.handler = async (opts) => {
 
 exports.builder = (yargs) =>
   yargs
-    .env('CML')
+    .env('CML_ASSET')
     .option('options', { default: exports.options, hidden: true })
     .options(exports.options);
 

--- a/bin/cml/check/create.js
+++ b/bin/cml/check/create.js
@@ -15,7 +15,7 @@ exports.handler = async (opts) => {
 
 exports.builder = (yargs) =>
   yargs
-    .env('CML')
+    .env('CML_CHECK')
     .option('options', { default: exports.options, hidden: true })
     .options(exports.options);
 

--- a/bin/cml/comment/create.js
+++ b/bin/cml/comment/create.js
@@ -13,7 +13,7 @@ exports.handler = async (opts) => {
 
 exports.builder = (yargs) =>
   yargs
-    .env('CML')
+    .env('CML_COMMENT')
     .option('options', { default: exports.options, hidden: true })
     .options(exports.options);
 

--- a/bin/cml/pr.js
+++ b/bin/cml/pr.js
@@ -7,7 +7,7 @@ exports.builder = (yargs) =>
   yargs
     .commandDir('./pr', { exclude: /\.test\.js$/ })
     .recommendCommands()
-    .env('CML')
+    .env('CML_PR')
     .options(
       Object.fromEntries(
         Object.entries(options).map(([key, value]) => [

--- a/bin/cml/pr/create.js
+++ b/bin/cml/pr/create.js
@@ -21,7 +21,7 @@ exports.handler = async (opts) => {
 
 exports.builder = (yargs) =>
   yargs
-    .env('CML')
+    .env('CML_PR')
     .option('options', { default: exports.options, hidden: true })
     .options(exports.options);
 

--- a/bin/cml/repo/prepare.js
+++ b/bin/cml/repo/prepare.js
@@ -15,7 +15,7 @@ exports.handler = async (opts) => {
 
 exports.builder = (yargs) =>
   yargs
-    .env('CML')
+    .env('CML_REPO')
     .option('options', { default: exports.options, hidden: true })
     .options(exports.options);
 

--- a/bin/cml/runner.js
+++ b/bin/cml/runner.js
@@ -7,7 +7,7 @@ exports.builder = (yargs) =>
   yargs
     .commandDir('./runner', { exclude: /\.test\.js$/ })
     .recommendCommands()
-    .env('CML')
+    .env('CML_RUNNER')
     .options(
       Object.fromEntries(
         Object.entries(options).map(([key, value]) => [

--- a/bin/cml/runner/launch.js
+++ b/bin/cml/runner/launch.js
@@ -449,7 +449,7 @@ exports.handler = async (opts) => {
 
 exports.builder = (yargs) =>
   yargs
-    .env('CML')
+    .env('CML_RUNNER')
     .option('options', { default: exports.options, hidden: true })
     .options(exports.options);
 

--- a/bin/cml/tensorboard/connect.js
+++ b/bin/cml/tensorboard/connect.js
@@ -101,7 +101,7 @@ exports.handler = async (opts) => {
 
 exports.builder = (yargs) =>
   yargs
-    .env('CML')
+    .env('CML_TENSORBOARD')
     .option('options', { default: exports.options, hidden: true })
     .options(exports.options);
 

--- a/bin/cml/workflow/rerun.js
+++ b/bin/cml/workflow/rerun.js
@@ -13,7 +13,7 @@ exports.handler = async (opts) => {
 
 exports.builder = (yargs) =>
   yargs
-    .env('CML')
+    .env('CML_WORKFLOW')
     .option('options', { default: exports.options, hidden: true })
     .options(exports.options);
 


### PR DESCRIPTION
Without this pull request, all the CML commands are broken when environment variables for some other commands are present. 
* Same as #1272 but done right[^1]
* Reverts (unreleased) convention change from `CML_OPTION` back to `CML_COMMAND_OPTION`

[^1]: See yargs/yargs#873 for context.