### PR TITLE
Add the option to define the target branch on pull requests

### DIFF
--- a/bin/cml/pr/create.js
+++ b/bin/cml/pr/create.js
@@ -54,6 +54,10 @@ exports.options = kebabcaseKeys({
     type: 'string',
     description: 'Pull request branch name'
   },
+  targetBranch: {
+    type: 'string',
+    description: 'Pull request target branch name'
+  },
   title: {
     type: 'string',
     description: 'Pull request title'

--- a/src/cml.js
+++ b/src/cml.js
@@ -547,19 +547,22 @@ class CML {
     const shaShort = sha.substr(0, 8);
 
     let target = await this.branch();
-    const targetBranchExists =
-      targetBranch &&
-      (
+
+    if (targetBranch) {
+      try {
         await exec(
           'git',
           'ls-remote',
+          '--exit-code',
           await exec('git', 'config', '--get', `remote.${remote}.url`),
           targetBranch
-        )
-      ).includes(targetBranch);
+        );
 
-    if (targetBranchExists) {
-      target = targetBranch;
+        target = targetBranch;
+      } catch (error) {
+        winston.error('The target branch does not exist.');
+        process.exit(1);
+      }
     }
 
     const source = branch || `${target}-cml-pr-${shaShort}`;

--- a/src/cml.js
+++ b/src/cml.js
@@ -508,6 +508,7 @@ class CML {
       md,
       skipCi,
       branch,
+      targetBranch,
       message,
       title,
       body,
@@ -545,7 +546,22 @@ class CML {
     const sha = await this.triggerSha();
     const shaShort = sha.substr(0, 8);
 
-    const target = await this.branch();
+    let target = await this.branch();
+    const targetBranchExists =
+      targetBranch &&
+      (
+        await exec(
+          'git',
+          'ls-remote',
+          await exec('git', 'config', '--get', `remote.${remote}.url`),
+          targetBranch
+        )
+      ).includes(targetBranch);
+
+    if (targetBranchExists) {
+      target = targetBranch;
+    }
+
     const source = branch || `${target}-cml-pr-${shaShort}`;
 
     const branchExists = (


### PR DESCRIPTION
Adds the option to select the target branch of the PR to be created.
In case of not setting the `targetBranch` option, the behavior is the same as before, it will take the currently selected branch.

An example where the PR will be created with the `main` branch as the target branch:
`cml pr create . --targetBranch=main`