### PR TITLE
Revert GitLab Runner version pin

### DIFF
--- a/src/drivers/gitlab.js
+++ b/src/drivers/gitlab.js
@@ -186,7 +186,7 @@ class Gitlab {
       const bin = resolve(workdir, 'gitlab-runner');
       if (!(await fse.pathExists(bin))) {
         const arch = process.platform === 'darwin' ? 'darwin' : 'linux';
-        const url = `https://gitlab-runner-downloads.s3.amazonaws.com/v15.7.3/binaries/gitlab-runner-${arch}-amd64`;
+        const url = `https://gitlab-runner-downloads.s3.amazonaws.com/latest/binaries/gitlab-runner-${arch}-amd64`;
         await download({ url, path: bin });
         await fs.chmod(bin, '777');
       }


### PR DESCRIPTION
Reverts #1333 and closes #1335; to be merged as soon as [!3881](https://gitlab.com/gitlab-org/gitlab-runner/-/merge_requests/3881) is released.