### PR TITLE
handle paths with spaces

### DIFF
--- a/src/cml.js
+++ b/src/cml.js
@@ -220,9 +220,10 @@ class CML {
       };
       const visitor = async (node) => {
         if (node.url && !isWatermark(node)) {
+          const encodedUrl = encodeURIComponent(node.url);
           const absolutePath = path.resolve(
             path.dirname(markdownFile),
-            node.url
+            encodedUrl
           );
           if (!triggerFile && watch) watcher.add(absolutePath);
           try {


### PR DESCRIPTION
Resolving #1369 

We can use the `encodeURIComponent` function to encode any spaces in the `node.url` property before passing it to the `path.resolve` function.

This should ensure that image URLs with spaces are resolved correctly and passed to the publish function.