### PR TITLE
Pin Node.js version on GitHub Actions test job

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -45,6 +45,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - uses: actions/setup-python@v2
         with:
           python-version: 3.9


### PR DESCRIPTION
GitHub Actions' default Node.js version was upgraded (https://github.com/actions/runner-images/issues/7002) to version 18 recently and https://github.com/emscripten-core/emscripten/issues/16913 was breaking our tests.