### PR TITLE
fix: replace deprecated gitlab ci var

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -28,7 +28,7 @@ jobs:
           ; user.password = '${{ github.token }}'
           ; user.password_confirmation = '${{ github.token }}'
           ; user.save!
-          ; token = user.personal_access_tokens.create(scopes: [:api], name: 'Token')
+          ; token = user.personal_access_tokens.create(scopes: [:api], name: 'Token', expires_at: 1.days.from_now)
           ; token.set_token('${{ github.token }}')
           ; token.save!
           "

--- a/src/drivers/gitlab.js
+++ b/src/drivers/gitlab.js
@@ -530,7 +530,10 @@ class Gitlab {
   }
 
   get branch() {
-    return process.env.CI_BUILD_REF_NAME;
+    if ('CI_COMMIT_BRANCH' in process.env) {
+      return process.env.CI_COMMIT_BRANCH
+    }
+    return process.env.CI_COMMIT_REF_NAME;
   }
 
   get userEmail() {

--- a/src/drivers/gitlab.js
+++ b/src/drivers/gitlab.js
@@ -531,7 +531,7 @@ class Gitlab {
 
   get branch() {
     if ('CI_COMMIT_BRANCH' in process.env) {
-      return process.env.CI_COMMIT_BRANCH
+      return process.env.CI_COMMIT_BRANCH;
     }
     return process.env.CI_COMMIT_REF_NAME;
   }


### PR DESCRIPTION
GitLab 16.x deprecated several variables including CI_BUILD_REF_NAME. In order to be exhaustive, two variables are replacing it: CI_COMMIT_BRANCH (prefered) and CI_COMMIT_REF_NAME.

Issue: #1403

I put the two variables in order to cover most of the cases one can think of in terms of pipeline trigger.

@dacbd 