### PR TITLE
Update CUDA on container images

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -21,7 +21,7 @@ jobs:
           - base: 1
             ubuntu: 20.04
             python: 3.8
-            cuda: 11.2.1
+            cuda: 11.2.2
             cudnn: 8
           - latest: true # update the values below after introducing a new major version
             base: 1


### PR DESCRIPTION
It appears nvidia removed some of their images: https://hub.docker.com/r/nvidia/cuda/tags?page=1&name=11.2.1