### PR TITLE
runner: Convert idle-timeout="never" to 0 with GitLab driver

### DIFF
--- a/src/drivers/gitlab.js
+++ b/src/drivers/gitlab.js
@@ -200,7 +200,7 @@ class Gitlab {
       const { protocol, host } = new URL(this.repo);
       const { token } = await this.registerRunner({ tags: labels, name });
 
-      var waitTimeout = idleTimeout;
+      let waitTimeout = idleTimeout;
       if (idleTimeout === 'never') {
         waitTimeout = '0';
       }

--- a/src/drivers/gitlab.js
+++ b/src/drivers/gitlab.js
@@ -200,8 +200,9 @@ class Gitlab {
       const { protocol, host } = new URL(this.repo);
       const { token } = await this.registerRunner({ tags: labels, name });
 
+      var waitTimeout = idleTimeout;
       if (idleTimeout === 'never') {
-        idleTimeout = '0';
+        waitTimeout = '0';
       }
 
       let dockerVolumesTpl = '';
@@ -214,7 +215,7 @@ class Gitlab {
         --url "${protocol}//${host}" \
         --name "${name}" \
         --token "${token}" \
-        --wait-timeout ${idleTimeout} \
+        --wait-timeout ${waitTimeout} \
         --executor "${IN_DOCKER ? 'shell' : 'docker'}" \
         --docker-image "iterativeai/cml:${gpu ? 'latest-gpu' : 'latest'}" \
         ${gpu ? '--docker-runtime nvidia' : ''} \

--- a/src/drivers/gitlab.js
+++ b/src/drivers/gitlab.js
@@ -200,6 +200,10 @@ class Gitlab {
       const { protocol, host } = new URL(this.repo);
       const { token } = await this.registerRunner({ tags: labels, name });
 
+      if (idleTimeout === 'never') {
+        idleTimeout = '0';
+      }
+
       let dockerVolumesTpl = '';
       dockerVolumes.forEach((vol) => {
         dockerVolumesTpl += `--docker-volumes ${vol} `;


### PR DESCRIPTION
GitLab runners do not support "never" as an argument for --wait-timeout, instead this should be 0, which by default is no timeout.

Fixes #1407