### PR TITLE
Fix flawed `unist-util-visit` usage

### DIFF
--- a/src/cml.js
+++ b/src/cml.js
@@ -213,7 +213,9 @@ class CML {
     const publishLocalFiles = async (tree) => {
       const nodes = [];
 
-      visit(tree, ['definition', 'image', 'link'], (node) => { nodes.push(node) });
+      visit(tree, ['definition', 'image', 'link'], (node) => {
+        nodes.push(node)
+      });
 
       const isWatermark = (node) => {
         return node.title && node.title.startsWith('CML watermark');

--- a/src/cml.js
+++ b/src/cml.js
@@ -214,7 +214,7 @@ class CML {
       const nodes = [];
 
       visit(tree, ['definition', 'image', 'link'], (node) => {
-        nodes.push(node)
+        nodes.push(node);
       });
 
       const isWatermark = (node) => {

--- a/src/cml.js
+++ b/src/cml.js
@@ -213,7 +213,7 @@ class CML {
     const publishLocalFiles = async (tree) => {
       const nodes = [];
 
-      visit(tree, ['definition', 'image', 'link'], (node) => nodes.push(node));
+      visit(tree, ['definition', 'image', 'link'], (node) => { nodes.push(node) });
 
       const isWatermark = (node) => {
         return node.title && node.title.startsWith('CML watermark');


### PR DESCRIPTION
It turns out that [`unist-util-visit`](https://github.com/syntax-tree/unist-util-visit) takes a [`Visitor`](https://github.com/syntax-tree/unist-util-visit/blob/9121f9910c315867bd9a0c960ef5e95715790c2a/readme.md?plain=1#L142-L179) function, that may optionally return an [`Index`](https://github.com/syntax-tree/unist-util-visit/blob/9121f9910c315867bd9a0c960ef5e95715790c2a/readme.md?plain=1#L174) to ["specify the
sibling to traverse after [the current] `node` is traversed"](https://github.com/syntax-tree/unist-util-visit/blob/9121f9910c315867bd9a0c960ef5e95715790c2a/readme.md?plain=1#L153C61-L154C46), but [`Array.prototype.push` "returns the new length of the array"](https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.push), causing an erratic tree traversal.

### Minimal example

```javascript
const remark = require('remark');
const visit = require('unist-util-visit');

const report = `
# Heading 1
[![description](https://img.shields.io/badge/...)](https://studio.iterative.ai/team/...)
## Heading 2
![one](./one)
![two](./two)
![three](./three)
`;

function plugin(tree) {
  const nodes = [];

  // The visitor function returns the result of calling nodes.push()
  visit(tree, ['definition', 'image', 'link'], (node) => nodes.push(node));

  nodes.map(({url}) => console.log(url));
}

remark().use(() => plugin).process(report);
```

```console
https://studio.iterative.ai/team/...
https://img.shields.io/badge/...
./one
./three
./three
```