### PR TITLE
Rename GitLab self-hosted test job

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -1,7 +1,7 @@
 name: GitLab
 on: pull_request
 jobs:
-  test:
+  gitlab:
     runs-on: ubuntu-latest
     services:
       gitlab:


### PR DESCRIPTION
It was causing trouble with branch protection (same name as `jest` tests, thus, also required)