### PR TITLE
Fix CML version on container images

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -4,6 +4,9 @@ on:
       release:
         required: true
         type: boolean
+      version:
+        required: false
+        type: string
 jobs:
   images:
     runs-on: ubuntu-latest
@@ -33,8 +36,11 @@ jobs:
           fetch-depth: 0
       - name: Metadata
         id: metadata
+        env:
+          CML_VERSION: ${{ inputs.version }}
         run: |
           latest_tag=$(git describe --tags | cut -d- -f1)
+          test -n "$CML_VERSION" && latest_tag="$CML_VERSION"
           cml_version=${latest_tag##v}
           dvc_version=$(python3 -c '
           from distutils.version import StrictVersion as Ver

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -98,6 +98,8 @@ jobs:
   packages:
     needs: [lint, test, test-os]
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.publish.outputs.version }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -106,8 +108,10 @@ jobs:
         with:
           registry-url: https://registry.npmjs.org
       - run: npm install
-      - run: |
+      - id: publish
+        run: |
           VERSION=$(jq -r .version < package.json)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
           npm install --dry-run @dvcorg/cml@$VERSION ||
           npm ${{ inputs.release && 'publish' || 'publish --dry-run' }}
         env:
@@ -133,3 +137,4 @@ jobs:
     uses: ./.github/workflows/images.yml
     with:
       release: ${{ inputs.release || false }}
+      version: ${{ needs.packages.outputs.version }}


### PR DESCRIPTION
Container images were shipping CML 0.20.0 after 0.20.1 was released; I hope to get this right on the first try. 🤞🏼 