### PR TITLE
Use base URL of GitLab for the `/uploads` URLs

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -59,6 +59,11 @@ jobs:
           | jq -r .id \
           | xargs -0 printf "hash=%s" >> $GITHUB_OUTPUT
       - run: npm ci
+      - uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true
+        env:
+          TEST_GITLAB_TOKEN: ${{ github.token }}
       - name: Run cml-send-comment
         run: |
           node bin/cml.js send-comment \

--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -59,11 +59,6 @@ jobs:
           | jq -r .id \
           | xargs -0 printf "hash=%s" >> $GITHUB_OUTPUT
       - run: npm ci
-      - uses: mxschmitt/action-tmate@v3
-        with:
-          limit-access-to-actor: true
-        env:
-          TEST_GITLAB_TOKEN: ${{ github.token }}
       - name: Run cml-send-comment
         run: |
           node bin/cml.js send-comment \

--- a/bin/cml/asset/publish.e2e.test.js
+++ b/bin/cml/asset/publish.e2e.test.js
@@ -125,7 +125,7 @@ describe('CML e2e', () => {
       'assets/test.svg'
     );
 
-    expect(output.startsWith('https://')).toBe(true);
+    expect(output.startsWith('/uploads/')).toBe(true);
   });
 
   test('cml publish /nonexistent produces file error', async () => {

--- a/src/cml.e2e.test.js
+++ b/src/cml.e2e.test.js
@@ -144,8 +144,8 @@ describe('Gitlab tests', () => {
       native: true
     });
 
-    expect(output.startsWith('https://')).toBe(true);
-    expect(output.includes('cml=png')).toBe(true);
+    expect(output.startsWith('/uploads/')).toBe(true);
+    expect(output.includes('cml=png')).toBe(false);
   });
 
   test('Publish image using gl with markdown', async () => {
@@ -159,9 +159,9 @@ describe('Gitlab tests', () => {
       native: true
     });
 
-    expect(output.startsWith('![](https://')).toBe(true);
+    expect(output.startsWith('![](/uploads/')).toBe(true);
     expect(output.endsWith(` "${title}")`)).toBe(true);
-    expect(output.includes('cml=png')).toBe(true);
+    expect(output.includes('cml=png')).toBe(false);
   });
 
   test('Publish a non image file using gl in markdown', async () => {
@@ -175,9 +175,9 @@ describe('Gitlab tests', () => {
       native: true
     });
 
-    expect(output.startsWith(`[${title}](https://`)).toBe(true);
+    expect(output.startsWith(`[${title}](/uploads/`)).toBe(true);
     expect(output.endsWith(')')).toBe(true);
-    expect(output.includes('cml=pdf')).toBe(true);
+    expect(output.includes('cml=pdf')).toBe(false);
   });
 
   test('Publish a non image file using native', async () => {
@@ -191,9 +191,9 @@ describe('Gitlab tests', () => {
       native: true
     });
 
-    expect(output.startsWith(`[${title}](https://`)).toBe(true);
+    expect(output.startsWith(`[${title}](/uploads/`)).toBe(true);
     expect(output.endsWith(')')).toBe(true);
-    expect(output.includes('cml=pdf')).toBe(true);
+    expect(output.includes('cml=pdf')).toBe(false);
   });
 
   test('Publish should fail with an invalid driver', async () => {

--- a/src/cml.js
+++ b/src/cml.js
@@ -346,12 +346,14 @@ class CML {
       ({ mime, uri } = await upload(opts));
     }
 
-    if (!rmWatermark) {
+    if (!rmWatermark && !native) {
       const [, type] = mime.split('/');
       uri = watermarkUri({ uri, type });
     }
 
-    uri = preventcacheUri({ uri });
+    if (!native) {
+      uri = preventcacheUri({ uri });
+    }
 
     if (md && mime.match('(image|video)/.*'))
       return `![](${uri}${title ? ` "${title}"` : ''})`;

--- a/src/drivers/gitlab.js
+++ b/src/drivers/gitlab.js
@@ -131,8 +131,6 @@ class Gitlab {
   }
 
   async upload(opts = {}) {
-    const { repo } = this;
-
     const projectPath = await this.projectPath();
     const endpoint = `/projects/${projectPath}/uploads`;
     const { size, mime, data } = await fetchUploadData(opts);

--- a/src/drivers/gitlab.js
+++ b/src/drivers/gitlab.js
@@ -141,7 +141,7 @@ class Gitlab {
 
     const { url } = await this.request({ endpoint, method: 'POST', body });
 
-    return { uri: `${repo}${url}`, mime, size };
+    return { uri: `${await this.repoBase()}${url}`, mime, size };
   }
 
   async runnerToken(body) {

--- a/src/drivers/gitlab.js
+++ b/src/drivers/gitlab.js
@@ -139,7 +139,7 @@ class Gitlab {
 
     const { url } = await this.request({ endpoint, method: 'POST', body });
 
-    return { uri: `${await this.repoBase()}${url}`, mime, size };
+    return { uri: url, mime, size };
   }
 
   async runnerToken(body) {


### PR DESCRIPTION
Could close https://github.com/iterative/cml/issues/1478; not sure about compatibility with old GitLab versions, though.