### PR TITLE
Fix `terraform` install commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,12 +61,10 @@ RUN add-apt-repository ppa:git-core/ppa --yes \
  && rm --recursive --force /var/lib/apt/lists/*
 
 # INSTALL TERRAFORM
-RUN curl --location https://apt.releases.hashicorp.com/gpg | sudo apt-key add - \
- && apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release --codename --short) main" \
- && apt update \
- && apt-get install --yes terraform \
- && apt-get clean \
- && rm --recursive --force /var/lib/apt/lists/*
+RUN curl --remote-name --location https://releases.hashicorp.com/terraform/1.9.8/terraform_1.9.8_linux_amd64.zip \
+ && unzip terraform_1.9.8_linux_amd64.zip \
+ && mv terraform /usr/bin \
+ && rm LICENSE.txt terraform_1.9.8_linux_amd64.zip
 
 # INSTALL LEO
 RUN curl --location https://github.com/iterative/terraform-provider-iterative/releases/latest/download/leo_linux_amd64 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,8 @@ RUN add-apt-repository ppa:git-core/ppa --yes \
 RUN curl --remote-name --location https://releases.hashicorp.com/terraform/1.9.8/terraform_1.9.8_linux_amd64.zip \
  && unzip terraform_1.9.8_linux_amd64.zip \
  && mv terraform /usr/bin \
- && rm LICENSE.txt terraform_1.9.8_linux_amd64.zip
+ && rm LICENSE.txt terraform_1.9.8_linux_amd64.zip \
+ && terraform version # make sure it works
 
 # INSTALL LEO
 RUN curl --location https://github.com/iterative/terraform-provider-iterative/releases/latest/download/leo_linux_amd64 \


### PR DESCRIPTION
Ubuntu 18.04 repositories have been gone for ages ([build error](https://github.com/iterative/cml/actions/runs/11490088598/job/31980413320#step:8:1323)):

```console
5.794 E: The repository 'https://apt.releases.hashicorp.com/ bionic Release' does not have a Release file.
```