### PR TITLE
Add null default for old gitlab runnerToken flow (#1491)

### DIFF
--- a/src/drivers/gitlab.e2e.test.js
+++ b/src/drivers/gitlab.e2e.test.js
@@ -49,6 +49,8 @@ describe('Non Enviromental tests', () => {
 
   test('Runner token', async () => {
     const output = await client.runnerToken();
+
+    expect(output).not.toBeUndefined();
     expect(output.length >= 20).toBe(true);
   });
 

--- a/src/drivers/gitlab.js
+++ b/src/drivers/gitlab.js
@@ -147,7 +147,7 @@ class Gitlab {
     const legacyEndpoint = `/projects/${projectPath}`;
     const endpoint = `/user/runners`;
 
-    const { id, runners_token: runnersToken } = await this.request({
+    const { id, runners_token: runnersToken = null } = await this.request({
       endpoint: legacyEndpoint
     });
 


### PR DESCRIPTION
When legacy gitlab runner registration token is disabled old flow returns an undefined token which causes the null check to enter the new token code path to fail.

Tested runner-token e2e test with the following cases on a local gitlab repository:
- **Pre change** w/ legacy runner registration **enabled**:
  - runnerToken returned via legacy code path is valid, test passes.
- **Pre change** w/ legacy runner registration **disabled**: 
  - runnerToken returned is undefined when executing legacy code path and test fails on `output.length`.
- **Post change** w/ legacy runner registration **enabled**:
  - runnerToken returned via legacy code path is valid, test passes.
- **Post change** w/  legacy runner registration **disabled**:
  - runnerToken returned is null when executing legacy code path, new token code path is entered via null check and valid runner token is received.

Not sure how to incorporate these tests into the CML repo without setting up additional test repos...